### PR TITLE
Add three launcher plugins by devnullvoid

### DIFF
--- a/plugins/devnullvoid-command-runner.json
+++ b/plugins/devnullvoid-command-runner.json
@@ -1,18 +1,12 @@
 {
   "name": "Command Runner",
-  "capabilities": [
-    "launcher"
-  ],
+  "capabilities": ["launcher"],
   "category": "utilities",
   "repo": "https://github.com/devnullvoid/dms-command-runner",
   "author": "devnullvoid",
   "description": "Execute shell commands from the launcher with history tracking, common shortcuts, and terminal/background execution modes",
   "dependencies": [],
-  "compositors": [
-    "niri",
-    "hyprland"
-  ],
-  "distro": [
-    "any"
-  ]
+  "compositors": ["niri", "hyprland"],
+  "distro": ["any"],
+  "screenshot": "https://github.com/devnullvoid/dms-command-runner/blob/main/screenshot.png"
 }

--- a/plugins/devnullvoid-emoji-launcher.json
+++ b/plugins/devnullvoid-emoji-launcher.json
@@ -1,18 +1,12 @@
 {
   "name": "Emoji & Unicode Launcher",
-  "capabilities": [
-    "launcher"
-  ],
+  "capabilities": ["launcher"],
   "category": "utilities",
   "repo": "https://github.com/devnullvoid/dms-emoji-launcher",
   "author": "devnullvoid",
   "description": "Search and copy 300+ emojis and 100+ unicode characters directly from the launcher with instant clipboard copying",
   "dependencies": [],
-  "compositors": [
-    "niri",
-    "hyprland"
-  ],
-  "distro": [
-    "any"
-  ]
+  "compositors": ["niri", "hyprland"],
+  "distro": ["any"],
+  "screenshot": "https://github.com/devnullvoid/dms-emoji-launcher/blob/main/screenshot.png"
 }

--- a/plugins/devnullvoid-web-search.json
+++ b/plugins/devnullvoid-web-search.json
@@ -1,18 +1,12 @@
 {
   "name": "Web Search",
-  "capabilities": [
-    "launcher"
-  ],
+  "capabilities": ["launcher"],
   "category": "utilities",
   "repo": "https://github.com/devnullvoid/dms-web-search",
   "author": "devnullvoid",
   "description": "Search the web with 23+ built-in search engines plus custom search engine support with keyword-based selection",
   "dependencies": [],
-  "compositors": [
-    "niri",
-    "hyprland"
-  ],
-  "distro": [
-    "any"
-  ]
+  "compositors": ["niri", "hyprland"],
+  "distro": ["any"],
+  "screenshot": "https://github.com/devnullvoid/dms-web-search/blob/main/screenshot.png"
 }


### PR DESCRIPTION
This PR adds three new launcher plugins:

**Emoji & Unicode Launcher**
- Search and copy 300+ emojis and 100+ unicode characters
- Repo: https://github.com/devnullvoid/dms-emoji-launcher

**Command Runner**
- Execute shell commands with history tracking and shortcuts
- Repo: https://github.com/devnullvoid/dms-command-runner

**Web Search**
- Search with 23+ built-in search engines + custom engine support
- Repo: https://github.com/devnullvoid/dms-web-search

All plugins follow DMS best practices and are fully tested and working.