### PR TITLE
:sparkles: add wallpaper discovery widget

### DIFF
--- a/plugins/lucyfire-gitmoji-launcher.json
+++ b/plugins/lucyfire-gitmoji-launcher.json
@@ -5,7 +5,8 @@
         "launcher"
     ],
     "category": "utilities",
-    "repo": "https://github.com/lucyfire/dms-gitmoji-launcher",
+    "repo": "https://github.com/lucyfire/dms-plugins",
+    "path": "gitmojiLauncher",
     "author": "lucyfire",
     "description": "Search and copy gitmojis from https://gitmoji.dev",
     "dependencies": [
@@ -18,5 +19,5 @@
     "distro": [
         "any"
     ],
-    "screenshot": "https://github.com/lucyfire/dms-gitmoji-launcher/blob/master/screenshot.png?raw=true"
+    "screenshot": "https://github.com/Lucyfire/dms-plugins/blob/master/gitmojiLauncher/screenshot.png?raw=true"
 }

--- a/plugins/lucyfire-wallpaper-discovery.json
+++ b/plugins/lucyfire-wallpaper-discovery.json
@@ -1,0 +1,23 @@
+{
+    "id": "wallpaperDiscovery",
+    "name": "Wallpaper Discovery",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/lucyfire/dms-plugins",
+    "path": "wallpaperDiscovery",
+    "author": "lucyfire",
+    "description": "Search and download wallpapers",
+    "dependencies": [
+        "curl"
+    ],
+    "compositors": [
+        "niri",
+        "hyprland"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://github.com/Lucyfire/dms-plugins/blob/master/wallpaperDiscovery/screenshot.png?raw=true"
+}


### PR DESCRIPTION
Add Wallpaper discovery widget

- Search for wallpapers from providers (currently only unsplash is supported)
- repo: https://github.com/Lucyfire/dms-plugins/tree/master/wallpaperDiscovery

---
Update gitmoji repo to point to the new monorepo