### PR TITLE
:sparkles: add alarm clock widget

### DIFF
--- a/plugins/lucyfire-alarm-clock.json
+++ b/plugins/lucyfire-alarm-clock.json
@@ -1,0 +1,23 @@
+{
+    "id": "alarmClock",
+    "name": "Alarm Clock",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/lucyfire/dms-plugins",
+    "path": "alarmClock",
+    "author": "lucyfire",
+    "description": "An alarm clock widget",
+    "dependencies": [
+        "qt6-multimedia"
+    ],
+    "compositors": [
+        "niri",
+        "hyprland"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://github.com/Lucyfire/dms-plugins/blob/master/alarmClock/alarms.png?raw=true"
+}


### PR DESCRIPTION
Add Alarm Clock widget 

widget is in its early stages, but usable, adding for exposure and hopefully feedback
Notably you can't change the sound yet, and there is no persistence of alarms between qs restarts (as such setting repeat on an alarm wont do anything)

repo: https://github.com/Lucyfire/dms-plugins/tree/master/alarmClock