### PR TITLE
Add Wallpaper Engine plugin

### DIFF
--- a/plugins/sgtaziz-linux-wallpaperengine.json
+++ b/plugins/sgtaziz-linux-wallpaperengine.json
@@ -1,0 +1,18 @@
+{
+	"id": "linuxWallpaperEngine",
+	"name": "Linux Wallpaper Engine",
+	"capabilities": ["wallpaper", "animation"],
+	"category": "appearance",
+	"repo": "https://github.com/sgtaziz/dms-wallpaperengine",
+	"author": "sgtaziz",
+	"description": "Animated wallpaper support using linux-wallpaperengine with Steam Workshop scenes",
+	"dependencies": ["linux-wallpaperengine"],
+	"compositors": [
+		"niri",
+		"hyprland"
+	],
+	"distro": [
+		"any"
+	],
+	"screenshot": "https://raw.githubusercontent.com/sgtaziz/dms-wallpaperengine/refs/heads/main/screenshot.png"
+}


### PR DESCRIPTION
This plugins allows utilizing Wallpaper Engine wallpapers from steam using [linux-wallpaperengine](https://github.com/Almamu/linux-wallpaperengine).

This plugin previously was part of DMS directly (see https://github.com/AvengeMedia/DankMaterialShell/pull/191)
However, its adding extra strain to the development when it is not a commonly used feature. Therefore, development will continue through this plugin.

This plugin also adds extra configuration features that didn't make sense to add as part of DMS directly - such as FPS, silent toggle, and configuration of scene-specific properties.