### PR TITLE
:sparkles: add display settings for hyprland

### DIFF
--- a/plugins/lucyfire-display-settings.json
+++ b/plugins/lucyfire-display-settings.json
@@ -1,0 +1,20 @@
+{
+    "id": "displaySettings",
+    "name": "Display Settings",
+    "capabilities": [
+        "manage-displays"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/lucyfire/dms-plugins",
+    "path": "displaySettings",
+    "author": "lucyfire",
+    "description": "Turn on/off displays",
+    "dependencies": [],
+    "compositors": [
+        "hyprland"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://github.com/Lucyfire/dms-plugins/blob/master/displaySettings/screenshot.png?raw=true"
+}


### PR DESCRIPTION
Adds 3 new ipc calls to open/close/toggle a menu that shows the connected displays
selecting a display turns it off/on depending on it's current state

repo: https://github.com/Lucyfire/dms-plugins/tree/master/displaySettings