### PR TITLE
Add dolarBlue plugin

### DIFF
--- a/plugins/psyreactor-dolarBlue.json
+++ b/plugins/psyreactor-dolarBlue.json
@@ -1,0 +1,14 @@
+{
+    "id": "dolarBlue",
+    "name": "Dolar Blue",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/psyreactor/dms-dolarBlue",
+    "author": "psyreactor",
+    "description": "Dolar Blue plugin for DankBar",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/psyreactor/dms-dolarBlue/raw/main/screenshot.png",
+    "requires_dms": ">0.0.28"
+}


### PR DESCRIPTION
DolarBlue plugin displays real-time Blue and official exchange rates from Bluelytics, includes a configurable refresh interval, and optionally shows popup buttons that open related links. 
The plugin is only useful for Argentina

— Argentina, you wouldn't understand…