### PR TITLE
ASUS Control Center

### DIFF
--- a/plugins/pseudofractal-asus-control-center.json
+++ b/plugins/pseudofractal-asus-control-center.json
@@ -1,0 +1,13 @@
+{
+    "id": "asusControlCenter",
+    "name": "ASUS Control Center",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/pseudofractal/AsusControl",
+    "author": "pseudofractal",
+    "description": "Manage Power Profiles and GPU Modes for ASUS Laptops directly from your DankBar.",
+    "dependencies": ["asusctl", "supergfxctl"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/pseudofractal/AsusControl/main/assets/popup.png"
+}


### PR DESCRIPTION
Adding a new widget specifically for ASUS laptops. It's a GUI for the standard [Asus-Linux](https://asus-linux.org/) stack, for easily switching  modes.

It wraps these two tools:
- [asusctl](https://gitlab.com/asus-linux/asusctl): Used to swap Power Profiles (Quiet/Balanced/Performance).
- [supergfxctl](https://gitlab.com/asus-linux/supergfxctl): Handles the GPU mode switching (Integrated/Hybrid/Dedicated).

## Features
- One-click switching. Icons and colors update based on the active mode.
- Dynamically grabs supported modes from the above tools.