### PR TITLE
feat: Add Display Manager plugin for Niri

### DIFF
--- a/plugins/felri-display-manager-niri.json
+++ b/plugins/felri-display-manager-niri.json
@@ -5,9 +5,9 @@
   "category": "system",
   "repo": "https://github.com/felri/display-manager-plugin-niri-dank-linux",
   "author": "felri",
-  "description": "Toggle Niri displays and control monitor hardware brightness via DDC/CI.",
+  "description": "Toggle Niri displays and control monitor hardware brightness, contrast, scale, refresh rate, and resolution.",
   "dependencies": ["ddcutil"],
   "compositors": ["niri"],
   "distro": ["any"],
-  "screenshot": "https://private-user-images.githubusercontent.com/56592364/530062610-a7dc5fc8-3d34-47bd-b118-aae94c62467f.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjY1OTc3MjksIm5iZiI6MTc2NjU5NzQyOSwicGF0aCI6Ii81NjU5MjM2NC81MzAwNjI2MTAtYTdkYzVmYzgtM2QzNC00N2JkLWIxMTgtYWFlOTRjNjI0NjdmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEyMjQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjI0VDE3MzAyOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE5ZDg4Y2U4NTRiNjFhMWRlYTU1YTU0MjRiNmRkYzZlZjdhNGUwZjYyOWI0N2FkZWU1YzJmMTRmMTU0ZWQ2ZjcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.MYXgjI6tqzIYc3a1pBWuq1kvlDoujVpmY4QqxO_VJQA"
+  "screenshot": "https://github.com/user-attachments/assets/5603ecb0-b8f0-4278-9360-6e895a5109e9"
 }


### PR DESCRIPTION

<img width="638" height="926" alt="Screenshot from 2025-12-24 20-09-22" src="https://github.com/user-attachments/assets/47024a3b-dbc6-4458-903d-9bd1ecea6983" />



A DankMaterialShell plugin that lets you:

- Toggle Niri displays on/off  
- Control hardware monitor brightness via DDC/CI  

