### PR TITLE
Adding Hyprland Submap

### DIFF
--- a/plugins/mesteryui-hyprlandsubmap.json
+++ b/plugins/mesteryui-hyprlandsubmap.json
@@ -1,0 +1,14 @@
+{
+    "id": "hyprlandSubmap",
+    "name": "Hyprland Submap",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/mesteryui/DMS_HyprlandSubmap",
+    "path": "",
+    "author": "Mester",
+    "description": "Shows the current submap in hyprland",
+    "dependencies": [],
+    "compositors": ["hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/mesteryui/DMS_HyprlandSubmap/raw/main/image_2025-12-24_20-47-31.png"
+}


### PR DESCRIPTION
This is a plugin that allows to see the current submap in Hyprland I created it because for me that have various submaps for some contexts it's problematic can't view in which I am I was inspired by waybar module to view the current Hyprland submap