### PR TITLE
feat: Add Display Manager plugin for Niri

### DIFF
--- a/plugins/felri-display-manager-niri.json
+++ b/plugins/felri-display-manager-niri.json
@@ -9,5 +9,5 @@
   "dependencies": ["ddcutil"],
   "compositors": ["niri"],
   "distro": ["any"],
-  "screenshot": "https://github.com/user-attachments/assets/5603ecb0-b8f0-4278-9360-6e895a5109e9"
+  "screenshot": "https://raw.githubusercontent.com/felri/display-manager-plugin-niri-dank-linux/refs/heads/main/assets/screenshot.png"
 }


### PR DESCRIPTION
<img width="638" height="926" alt="Screenshot from 2025-12-24 20-09-22" src="https://github.com/user-attachments/assets/47024a3b-dbc6-4458-903d-9bd1ecea6983" />



A DankMaterialShell plugin that lets you:

- Toggle Niri displays on/off  
- Control hardware monitor brightness via DDC/CI  

