### PR TITLE
feat: add cglavin50/dms-tailscale plugin

### DIFF
--- a/plugins/cglavin50-tailscale.json
+++ b/plugins/cglavin50-tailscale.json
@@ -1,0 +1,13 @@
+{
+    "id": "tailscale",
+    "name": "Tailscale Manager",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/cglavin50/dms-tailscale",
+    "author": "cglavin50",
+    "description": "Tailscale-toggle plugin for DankBar",
+    "dependencies": ["tailscale"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/cglavin50/dms-tailscale/raw/main/plugin-notif.png"
+}


### PR DESCRIPTION
Adds DMS-Tailscale plugin

(First PR, apologies if I missed anything)

Relatively simple plugin to manage a Tailscale connection at a glance. Uses a Timer + Process to stay in sync with cli tool usage, and allows for quick disconnect and reconnect to your tailnet as needed.

As Tailscale authentication persists after a successful session, this plugin does not need to manage any auth keys/secrets, just running `tailscale up` and `tailscale down` as needed.

Validation checks are failing due to existing plugin - see [failure](https://github.com/AvengeMedia/dms-plugin-registry/actions/runs/20564681879/job/59061254845?pr=67#step:9:44)