### PR TITLE
Desktop Command plugin

### DIFF
--- a/plugins/yayuuu-desktop-command.json
+++ b/plugins/yayuuu-desktop-command.json
@@ -1,0 +1,13 @@
+{
+    "id": "desktopCommand",
+    "name": "Desktop Command",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/yayuuu/desktopCommand",
+    "author": "yayuuu",
+    "description": "A widget that displays a command output on your desktop",
+    "dependencies": ["python3"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/yayuuu/desktopCommand/raw/main/assets/screenshot.jpg"
+}


### PR DESCRIPTION
A plugin for running any shell command and displaying its content on the desktop. It acts as a terminal emulator, that translates ANSI codes (including cursor jumps, saves, rewrites, etc.) to static HTML with colors. Allows running TUI applications that never exit due to built-in timeout mechanics (the app is killed after set amount of time and whatever it sent to sdout is being parsed).