### PR TITLE
feat: add hue manager plugin

### DIFF
--- a/plugins/derethil-hue-manager.json
+++ b/plugins/derethil-hue-manager.json
@@ -1,0 +1,13 @@
+{
+    "id": "hueManager",
+    "name": "Hue Manager",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/derethil/dms-hue-manager",
+    "author": "derethil",
+    "description": "Control your Philips Hue lights directly from DMS",
+    "dependencies": ["openhue-cli", "jq"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/derethil/dms-hue-manager/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds my Hue Manager plugin. 

This lets you control Philips Hue lights from a dank bar widget e.g. setting power state, temperature, color, etc. It depends on `openhue-cli` and `jq` for communication with the bridge. 