### PR TITLE
AMD GPU Monitor plugin

### DIFF
--- a/plugins/navidagz-amd-gpu-monitor.json
+++ b/plugins/navidagz-amd-gpu-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "amdGpuMonitor",
+    "name": "AMD GPU Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/navidagz/dms-amd-gpu-monitor",
+    "author": "navidagz",
+    "description": "Monitor AMD GPU usage, VRAM, temperature, power consumption and process usage.",
+    "dependencies": ["amdgpu_top"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/navidagz/dms-amd-gpu-monitor/refs/heads/main/screenshot.png"
+}


### PR DESCRIPTION
Real-time AMD GPU monitoring widget for DankMaterialShell that tracks GPU usage (GFX, Memory, Media Engine), VRAM statistics, temperature, power consumption, and per-process GPU utilization using the `amdgpu_top`. Features color-coded indicators for usage levels, animated progress bars, and a detailed popout panel showing comprehensive metrics including device name, individual engine usage, and a list of all GPU processes with their VRAM, GFX, and CPU usage. 
- Includes full GitHub Pages documentation with installation, configuration, troubleshooting guides, and automated Jekyll deployment via GitHub Actions.