### PR TITLE
Add Lenovo Battery Settings plugin

### DIFF
--- a/plugins/neoscaler-lenovo-battery-settings.json
+++ b/plugins/neoscaler-lenovo-battery-settings.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsLenovoBatterySettings",
+    "name": "Lenovo Battery Settings",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/neoscaler/dms-lenovo-battery-settings",
+    "author": "neoscaler",
+    "description": "Manage Lenovo battery settings like conservation mode",
+    "dependencies": ["ideapad_laptop", "polkit-agent"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/neoscaler/dms-lenovo-battery-settings/refs/heads/main/screenshot.png"
+}


### PR DESCRIPTION
Plugin for managing Lenovo battery conservation mode directly from the DankBar. 

Details please see at https://github.com/neoscaler/dms-lenovo-battery-settings.