### PR TITLE
feat: Add HomeAssistantMonitor

### DIFF
--- a/plugins/xxyangyoulin-hass.json
+++ b/plugins/xxyangyoulin-hass.json
@@ -1,0 +1,14 @@
+{
+  "id": "homeAssistantMonitor",
+  "name": "Home Assistant Monitor",
+  "capabilities": ["home-assistant-monitor", "dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/xxyangyoulin/dms-plugin-hass",
+  "author": "xxyangyoulin",
+  "description": "Monitor and display Home Assistant entity states in your status bar",
+  "dependencies": ["curl"],
+  "compositors": ["hyprland"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/xxyangyoulin/dms-plugin-hass/master/assets/screenshot.png",
+  "requires_dms": ">=1.2.0"
+}


### PR DESCRIPTION
Monitor and display Home Assistant entity states in your status bar