### PR TITLE
Add gitlab notifier plugin

### DIFF
--- a/plugins/psyreactor-gitlabNotifier.json
+++ b/plugins/psyreactor-gitlabNotifier.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/psyreactor/dms-gitlabNotifier",
     "author": "psyreactor",
     "description": "Shows in the DankBar the status of a GitLab scope (issues, MRs and incidents assigned to you)",
-    "dependencies": ["glab"],
+    "dependencies": ["glab","font-awesome"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://github.com/psyreactor/dms-gitlabNotifier/raw/main/screenshot.png",


### PR DESCRIPTION
Plugin show in the DankBar the status of a GitLab scope (issues, MRs and incidents assigned to you)