### PR TITLE
Add polyglot plugin

### DIFF
--- a/plugins/silzinc-polyglot.json
+++ b/plugins/silzinc-polyglot.json
@@ -1,0 +1,21 @@
+{
+  "id": "polyglot",
+  "name": "Polyglot",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/Silzinc/Polyglot",
+  "author": "Silzinc",
+  "description": "A WIP translation plugin. Currently supports DeepL's free API.",
+  "dependencies": [
+    "curl"
+  ],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/Silzinc/Polyglot/refs/heads/main/screenshot1.png"
+}


### PR DESCRIPTION
A translation widget for the dankbar using DeepL.

This plugin is a WIP, has not been tested on another machine than mine and only supports DeepL's free API, but hopefully it does not work too badly.