### PR TITLE
Add 'launcher' capability to DMS Sessionizer

### DIFF
--- a/plugins/leonardofranco01-dms-sessionizer.json
+++ b/plugins/leonardofranco01-dms-sessionizer.json
@@ -2,6 +2,7 @@
     "id": "dmsSessionizer",
     "name": "DMS Sessionizer",
     "capabilities": [
+        "launcher",
         "command-execution",
         "shell"
     ],


### PR DESCRIPTION
Add 'launcher' capability to DMS Sessionizer plugin so it can appear when searching for launcher plugins in the plugin registry