### PR TITLE
Add Pass launcher plugin

### DIFF
--- a/plugins/louiskottmann-dms-pass.json
+++ b/plugins/louiskottmann-dms-pass.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsPass",
+    "name": "Pass",
+    "capabilities": ["launcher"],
+    "category": "utilities",
+    "repo": "https://github.com/LouisKottmann/dms-pass",
+    "author": "LouisKottmann",
+    "description": "DMS Launcher plugin to fuzzy-search Pass entries and copy them to the clipboard.",
+    "dependencies": ["pass"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/LouisKottmann/dms-pass/1b01949c0e8d2433bfad4d52f5af466723a504d5/screenshot.png"
+}


### PR DESCRIPTION
Adds [Pass](https://www.passwordstore.org) launcher plugin that enables fuzzy-search and copy to clipboard of pass entries.

![dms-pass screenshot](https://github.com/LouisKottmann/dms-pass/raw/master/screenshot.png)

I kept it simple, and I dogfood it myself.

Cheers.