### PR TITLE
Add Dank RSS Widget plugin

### DIFF
--- a/plugins/brendonjl-dankrsswidget.json
+++ b/plugins/brendonjl-dankrsswidget.json
@@ -9,5 +9,5 @@
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": ""
+    "screenshot": "https://raw.githubusercontent.com/BrendonJL/dms-rss-widget/main/screenshot.png"
 }


### PR DESCRIPTION
## Summary
- Adds `dankRssWidget` — a desktop widget that displays RSS/Atom feeds with auto-refresh
- Repo: https://github.com/BrendonJL/dms-rss-widget

## Features
- RSS 2.0 and Atom feed support with auto-detection
- Configurable refresh interval and max items
- Feed management (add/edit/delete) with quick-add presets
- Appearance customization (background opacity, borders)
- Click-to-open in browser via xdg-open