### PR TITLE
add Tokyo Night - Night and Moon variant's

### DIFF
--- a/themes/tokyonight-night-moon/theme.json
+++ b/themes/tokyonight-night-moon/theme.json
@@ -1,6 +1,6 @@
 {
   "id": "tokyoNightNightMoon",
-  "name": "TokyoNight Night &amp; Moon variants",
+  "name": "TokyoNight Night and Moon",
   "version": "1.0.0",
   "author": "Will Adams (adapted from Avenge Media)",
   "description": "Popular Tokyo Night color scheme with vibrant blues and purples, Night and Moon variant",


### PR DESCRIPTION
This just adapts the current TokyoNight from Avenge Media (which seems to be the 'Storm' and 'Day' variant's) to use the 'Night' and 'Moon' versions of the theme. Colours were sourced from
[folke/tokyonight.nvim/tree/main/lua/tokyonight/colors](https://github.com/folke/tokyonight.nvim/tree/main/lua/tokyonight/colors)