### PR TITLE
Add Process List plugin (processList)

### DIFF
--- a/plugins/mithgroth-process-list.json
+++ b/plugins/mithgroth-process-list.json
@@ -1,0 +1,14 @@
+{
+    "id": "processList",
+    "name": "Process List",
+    "capabilities": ["desktop-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/Mithgroth/dms-process-list",
+    "author": "mith",
+    "description": "Desktop overlay widget for live process monitoring with grouping, sorting, and scope filters",
+    "dependencies": ["ps", "getconf"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Mithgroth/dms-process-list/main/screenshot.png",
+    "requires_dms": ">=0.1.18"
+}

--- a/plugins/mithgroth-process-list.json
+++ b/plugins/mithgroth-process-list.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/Mithgroth/dms-process-list",
     "author": "mith",
     "description": "Desktop overlay widget for live process monitoring with grouping, sorting, and scope filters",
-    "dependencies": ["ps", "getconf"],
+    "dependencies": ["dgop"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/Mithgroth/dms-process-list/main/screenshot.png",


### PR DESCRIPTION
Adds a new monitoring desktop widget plugin entry:

- Plugin: Process List
- Repo: https://github.com/Mithgroth/dms-process-list
- Category: monitoring
- Capabilities: desktop-widget
- Screenshot: https://raw.githubusercontent.com/Mithgroth/dms-process-list/main/screenshot.png

The registry id/name match the plugin manifest:
- id: processList
- name: Process List
