### PR TITLE
Add DankCaffeine plugin

### DIFF
--- a/plugins/firemonster612-dankcaffeine.json
+++ b/plugins/firemonster612-dankcaffeine.json
@@ -1,13 +1,13 @@
 {
     "id": "dankCaffeine",
     "name": "DankCaffeine",
-    "capabilities": ["dankbar-widget", "control-center"],
+    "capabilities": ["dankbar-widget"],
     "category": "utilities",
     "repo": "https://github.com/firemonster612/DankCaffeine",
     "author": "firemonster612",
-    "description": "Prevents screen from going idle. Toggle from the bar or Control Center, like GNOME Caffeine.",
+    "description": "Prevents screen from going idle. Toggle from the DankBar, like GNOME Caffeine.",
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": ""
+    "screenshot": "https://raw.githubusercontent.com/firemonster612/DankCaffeine/main/screenshot.png"
 }

--- a/plugins/firemonster612-dankcaffeine.json
+++ b/plugins/firemonster612-dankcaffeine.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankCaffeine",
+    "name": "DankCaffeine",
+    "capabilities": ["dankbar-widget", "control-center"],
+    "category": "utilities",
+    "repo": "https://github.com/firemonster612/DankCaffeine",
+    "author": "firemonster612",
+    "description": "Prevents screen from going idle. Toggle from the bar or Control Center, like GNOME Caffeine.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": ""
+}


### PR DESCRIPTION
## Summary

- Adds **DankCaffeine**, a DankBar widget that prevents screen idle/blanking using `systemd-inhibit`
- Zero dependencies, works on any compositor and distro with systemd
- Plugin repo: https://github.com/firemonster612/DankCaffeine