### PR TITLE
Add dooit widget

### DIFF
--- a/plugins/metalcar-dms-dooit.json
+++ b/plugins/metalcar-dms-dooit.json
@@ -1,0 +1,14 @@
+{
+    "id": "dooitPlugin",
+    "name": "Dooit Plugin",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/MetalCar/dms-dooit-widget",
+    "path": "",
+    "author": "MetalCar",
+    "description": "This plugin shows todays task and the oldest five without due date from dooit.",
+    "dependencies": ["dooit"],
+    "compositors": ["niri"],
+    "distro": ["arch"],
+    "screenshot": "https://raw.githubusercontent.com/MetalCar/dms-dooit-widget/refs/heads/main/screenshots/image.png"
+}


### PR DESCRIPTION
Adds DooitPlugin, a Dank Material Shell/Quickshell plugin that runs a small Python [Dooit](https://dooit-org.github.io/dooit/) collector, parses its JSON output, and shows a todo counter in the top bar. Clicking the pill opens a popout with todos due today and the 5 oldest todos without a due date.

<img width="681" height="381" alt="image" src="https://github.com/user-attachments/assets/36c3af81-86e8-4cfc-8e7e-f5823fcf777b" />