### PR TITLE
Add flatpakUpdates widget to plugins

### DIFF
--- a/plugins/merdely-flatpakUpdates.json
+++ b/plugins/merdely-flatpakUpdates.json
@@ -1,0 +1,14 @@
+{
+    "id": "flatpakUpdates",
+    "name": "Flatpak Updates",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/merdely/dms-plugins",
+    "path": "FlatpakUpdates",
+    "author": "Michael Erdely",
+    "description": "Check for and install Flatpak Updates",
+    "dependencies": ["flatpak"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/merdely/dms-plugins/main/screenshots/flatpakupdates-popout.png"
+}


### PR DESCRIPTION
This plugin is a DankBar widget that works very similarly to the System Updates DankBar widget. It shows the number of Flatpak Updates and will let the user click Update to install them.