### PR TITLE
Add markets widget plugin

### DIFF
--- a/plugins/tms-namespace-markets.json
+++ b/plugins/tms-namespace-markets.json
@@ -1,0 +1,13 @@
+{
+    "id": "markets",
+    "name": "Markets",
+    "capabilities": ["dankbar-widget"],
+    "category": "finance",
+    "repo": "https://github.com/TMS-Namespace/DMS-Markets-Plugin",
+    "author": "TMS-Namespace",
+    "description": "Semi-Live market prices for currencies, stocks, and commodities with charts",
+    "dependencies": ["curl"],
+    "compositors": ["niri"],
+    "distro": ["fedora"],
+    "screenshot": "https://github.com/TMS-Namespace/DMS-Markets-Plugin/blob/main/Images/Dark-Popup.png"
+}


### PR DESCRIPTION
A widget plugin that displays near-live market prices and charts directly in your desktop shell.