### PR TITLE
Add displayOutput plugin

### DIFF
--- a/plugins/xyzsteven-displayoutput.json
+++ b/plugins/xyzsteven-displayoutput.json
@@ -1,0 +1,13 @@
+{
+    "id": "displayOutput",
+    "name": "Display Output",
+    "capabilities": ["manage-displays"],
+    "category": "system",
+    "repo": "https://github.com/xyzsteven/dms-displayoutput",
+    "author": "xyzsteven",
+    "description": "A Hyprland DankMaterialShell plugin that allows you to manage your display outputs (PC Only, Mirror, Extend, Second Screen Only).",
+    "dependencies": [],
+    "compositors": ["hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/xyzsteven/dms-displayoutput/refs/heads/main/screenshot.png"
+}


### PR DESCRIPTION
### Description
This PR adds the `displayOutput` plugin to the registry. It is a standalone, modified fork of the original `displaySettings` plugin by Lucyfire, specifically focused on managing display outputs (PC Only, Mirror, Extend, Second Screen Only) for Hyprland.

### Validation Checks
- [x] Plugin JSON follows the required schema (`{username}-{plugin-name}.json`).
- [x] `id` is in camelCase and matches the repo's `plugin.json` exactly.
- [x] `name` matches the repo's `plugin.json` exactly.
- [x] Tested locally with `generate.py --validate` and `validate_links.py` (All checks passed).