### PR TITLE
Add Claude Code Usage plugin

### DIFF
--- a/plugins/titeya-claudecodeusage.json
+++ b/plugins/titeya-claudecodeusage.json
@@ -1,0 +1,13 @@
+{
+    "id": "claudeCodeUsage",
+    "name": "Claude Code Usage",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/titeya/dms-claudecode",
+    "author": "Nicolas Bellamy",
+    "description": "Monitor your Claude Code subscription usage with token tracking, rate limits, and daily activity charts",
+    "dependencies": ["jq"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/titeya/dms-claudecode/raw/master/screenshot.png"
+}


### PR DESCRIPTION
## New Plugin: Claude Code Usage

**Plugin ID:** `claudeCodeUsage`
**Category:** monitoring
**Capability:** dankbar-widget

A DankBar widget that monitors Claude Code subscription usage directly from the taskbar.

### Features
- Circular progress ring showing 5-hour rate limit utilization
- Detailed popout with 5h/7-day rate windows, token consumption, daily activity chart, and per-model breakdown
- Automatic subscription detection via the Anthropic OAuth API
- Configurable refresh interval (30s to 5min)
- Localization support (English and French)

### Dependencies
- `jq`

### Screenshot
![Screenshot](https://github.com/titeya/dms-claudecode/raw/master/screenshot.png)

### Validation
`generate.py --validate` passes successfully.