### PR TITLE
Media Controls Plus

### DIFF
--- a/plugins/lpv11-dms-media-controls-plus.json
+++ b/plugins/lpv11-dms-media-controls-plus.json
@@ -5,7 +5,7 @@
     "category": "utilities",
     "repo": "https://github.com/lpv11/dms-media-controls-plus",
     "author": "lpv11",
-    "description": "Media controls with full bar volume scroll",
+    "description": "Media controls with full bar volume scroll. Disables workspace scroll.",
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],


### PR DESCRIPTION
This is the Media Controls widget of the dank bar but with a setting for full bar volume scroll & scroll step. "Disables" workspace scroll. Needs to be placed at the center!

repo: https://github.com/lpv11/dms-media-controls-plus

This is AI generated btw, if you'd wish to reject it for that reason. Feel free to make cleanup changes to it if you want.