### PR TITLE
Add dankObsidian

### DIFF
--- a/plugins/samoggino-dankobsidian.json
+++ b/plugins/samoggino-dankobsidian.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankObsidian",
+    "name": "Dank Obsidian",
+    "description": "Quick access to your Obsidian vaults",
+    "capabilities": ["launcher"],
+    "category": "utilities",
+    "repo": "https://github.com/Samoggino/dankObsidian",
+    "author": "Samoggino",
+    "dependencies": ["obsidian"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "requires_dms": ">=1.4.0",
+    "screenshot": "https://raw.githubusercontent.com/Samoggino/dankObsidian/main/screenshot.png"
+}


### PR DESCRIPTION
This plugin enables quick access to Obsidian vaults directly from the launcher. It automatically detects vaults from both native and Flatpak configurations. It should be compatible with any distribution and compositor.