### PR TITLE
Add Music Lyrics plugin

### DIFF
--- a/plugins/gasiyu-musicLyrics.json
+++ b/plugins/gasiyu-musicLyrics.json
@@ -1,0 +1,13 @@
+{
+    "id": "musicLyrics",
+    "name": "Music Lyrics",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/gasiyu/dms-plugin-musiclyrics",
+    "author": "gasiyu",
+    "description": "Display synced music lyrics from multiple sources.",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Gasiyu/dms-plugin-musiclyrics/main/screenshots.png"
+}


### PR DESCRIPTION
# Music Lyrics

![](https://raw.githubusercontent.com/Gasiyu/dms-plugin-musiclyrics/main/screenshots.png)

A DankMaterialShell widget plugin that displays synced music lyrics from multiple sources right on the panel.

- No external dependencies, use XMLHttpRequest for network request and FileView for write and read from cache
- Project repo: https://github.com/Gasiyu/dms-plugin-musiclyrics