### PR TITLE
Add World Clock Multi plugin

### DIFF
--- a/plugins/szabolcsf-world-clock-multi.json
+++ b/plugins/szabolcsf-world-clock-multi.json
@@ -1,0 +1,13 @@
+{
+    "id": "worldClockMulti",
+    "name": "World Clock Multi",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/szabolcsf/dms-world-clock-multi",
+    "author": "Szabolcs Fazekas",
+    "description": "Display up to 5 timezones on the DankBar. Toggle between showing all at once or cycling one at a time at a configurable interval.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/szabolcsf/dms-world-clock-multi/raw/main/screenshot.png"
+}


### PR DESCRIPTION
A DankBar widget that displays up to 5 timezones on the bar. Features:                                                                                
                                                                                                                                                        
  - Two display modes: show all clocks at once, or cycle one at a time at a configurable interval (3–120s, default 15s)                                 
  - 24h / 12h time format toggle                                                                                                                        
  - Custom labels for each timezone (e.g. "NYC", "TYO")
  - Popout panel showing all configured clocks with city name, timezone ID, and current time
  - Any timezone from `timedatectl list-timezones` is supported
  - No external dependencies — uses the system `date` command with TZ for timezone conversion

  Repo: https://github.com/szabolcsf/dms-world-clock-multi