### PR TITLE
Add Magyar Névnapok plugin

### DIFF
--- a/plugins/szabolcsf-magyar-nevnapok.json
+++ b/plugins/szabolcsf-magyar-nevnapok.json
@@ -1,0 +1,13 @@
+{
+    "id": "magyarNevnapok",
+    "name": "Magyar Névnapok",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/szabolcsf/dms-nameday",
+    "author": "Szabolcs Fazekas",
+    "description": "Display the current Hungarian nameday on the DankBar. Shows today's name on the bar, with yesterday/today/tomorrow in the popout panel.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/szabolcsf/dms-nameday/raw/main/screenshot.png"
+}


### PR DESCRIPTION
A DankBar widget that displays Hungarian namedays (névnapok). Shows today's name on the bar pill, with yesterday/today/tomorrow in the popout panel.

  ### Features

  - Today's nameday displayed on the bar (e.g. "Géza")
  - Popout panel with yesterday, today (highlighted), and tomorrow cards
  - Tooltip sentence: "Ma Géza ünnepli névnapját, tegnap Mátyás ünnepelte, holnap pedig Edina névnapja lesz."
  - All 366 days embedded — no network requests or external dependencies

  ### Dependencies

  None.

  ### Validation

  `generate.py --validate` passes successfully.

  ![screenshot](https://github.com/szabolcsf/dms-nameday/raw/main/screenshot.png)