### PR TITLE
Edit description for lucyfire-display-settings.json

### DIFF
--- a/plugins/lucyfire-display-settings.json
+++ b/plugins/lucyfire-display-settings.json
@@ -8,7 +8,7 @@
     "repo": "https://github.com/lucyfire/dms-plugins",
     "path": "displaySettings",
     "author": "lucyfire",
-    "description": "Turn on/off displays",
+    "description": "Turn on/off displays for Hyprland",
     "dependencies": [],
     "compositors": [
         "hyprland"


### PR DESCRIPTION
Explicitly call out this plugin is for Hyprland, so users on niri/others know.