### PR TITLE
Add dnf and flatpak update widget

### DIFF
--- a/plugins/rahulmysore23-pkgUpdate.json
+++ b/plugins/rahulmysore23-pkgUpdate.json
@@ -1,0 +1,13 @@
+{
+    "id": "pkgUpdate",
+    "name": "Package Updates",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/rahulmysore23/dms-pkg-update",
+    "author": "rahulmysore23",
+    "description": "Check and manage DNF and Flatpak package updates from the bar.",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["fedora", "any"],
+    "screenshot": "https://raw.githubusercontent.com/rahulmysore23/dms-pkg-update/main/screenshot.png"
+}


### PR DESCRIPTION
## Package Updates Widget

  A DankBar widget that checks for pending DNF and Flatpak updates and lets you run them directly from the bar.

 ### Features
  - Bar pill showing total pending update count (DNF + Flatpak combined)
  - Popout with separate DNF and Flatpak sections, each listing pending packages/apps
  - "Update DNF" button — opens a terminal running `sudo dnf upgrade -y`
  - "Update Flatpak" button — opens a terminal running `flatpak update -y`
  - Configurable terminal app, refresh interval, and Flatpak toggle

  ### Plugin details
  - **ID:** `pkgUpdate`
  - **Repo:** https://github.com/rahulmysore23/dms-pkg-update
  - **Category:** system
  - **Compositors:** niri
  - **Distro:** Fedora / any DNF-based distro with optional Flatpak
  - **Dependencies:** `dnf` (standard), `flatpak` (optional)
  - **License:** MIT
