### PR TITLE
Bar Volume Control Overlay

### DIFF
--- a/plugins/lpv11-bar-volume-control-overlay.json
+++ b/plugins/lpv11-bar-volume-control-overlay.json
@@ -1,0 +1,13 @@
+{
+  "id": "barVolumeControlOverlay",
+  "name": "Bar Volume Control Overlay",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/lpv11/dms-bar-volume-control-overlay",
+  "author": "lpv11",
+  "description": "Invisible bar overlay that controls system volume via scroll and toggles mute on middle click.",
+  "dependencies": [],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/lpv11/dms-bar-volume-control-overlay/main/screenshot.png"
+}


### PR DESCRIPTION
Adds an invisible full bar overlay that controls volume with volume wheel and toggles mute with middle click. Disables workspace scroll. Needs to be placed in the center for full bar coverage.