### PR TITLE
Add Air Quality plugin

### DIFF
--- a/plugins/szabolcsf-air-quality.json
+++ b/plugins/szabolcsf-air-quality.json
@@ -1,0 +1,13 @@
+{
+    "id": "airQuality",
+    "name": "Air Quality",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/szabolcsf/dms-air-quality",
+    "author": "Szabolcs Fazekas",
+    "description": "Display the current Air Quality Index (AQI) on the bar with detailed pollutant breakdown. Supports US and European AQI scales with auto-location.",
+    "dependencies": ["curl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/szabolcsf/dms-air-quality/raw/main/screenshot.png"
+}


### PR DESCRIPTION
A DankBar widget that displays the current Air Quality Index (AQI) on the bar with a detailed pollutant breakdown in the popout panel.

  **Key Features:**
  - Color-coded AQI dot indicator on the bar pill (e.g. \`● AQI 42\`)
  - Supports both US AQI and European AQI scales
  - Auto-detect location via GeoIP (ip-api.com) or set manual coordinates
  - Popout panel with large AQI card and 6 pollutant readings: PM2.5, PM10, O₃, NO₂, SO₂, CO
  - Configurable refresh interval (5–60 min) with response caching

  **Data sources:** [Open-Meteo Air Quality API](https://open-meteo.com/en/docs/air-quality-api) (free, no API key) and [ip-api.com](http://ip-api.com/)
   for geolocation.

  **Dependencies:** curl

  **Repository:** https://github.com/szabolcsf/dms-air-quality