### PR TITLE
feat: add AdGuard VPN plugin to registry

### DIFF
--- a/plugins/bernardopg-adguard-vpn.json
+++ b/plugins/bernardopg-adguard-vpn.json
@@ -1,0 +1,14 @@
+{
+    "id": "adguardVPplugin",
+    "name": "AdGuard VPN",
+    "capabilities": ["vpn", "network", "dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/bernardopg/dms-adguard-vpn-plugin",
+    "author": "Bernardo Gomes",
+    "description": "Control, configure, and monitor adguardvpn-cli directly from DankBar",
+    "dependencies": ["adguardvpn-cli"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/bernardopg/dms-adguard-vpn-plugin/main/docs/screenshot.png",
+    "requires_dms": ">=1.4.0"
+}


### PR DESCRIPTION
## Summary

This PR adds a new plugin entry to the DMS plugin registry:

- **Plugin:** AdGuard VPN
- **ID:** `adguardVPplugin`
- **Repository:** https://github.com/bernardopg/dms-adguard-vpn-plugin
- **Category:** `system`

The plugin provides a DankBar widget to control, configure, and monitor `adguardvpn-cli` directly from DMS.

## Metadata Notes

- `id` and `name` exactly match the plugin repository `plugin.json`
- Includes required fields (`capabilities`, `dependencies`, `compositors`, `distro`, etc.)
- Includes a public screenshot URL
- Includes `requires_dms: ">=1.4.0"`

## Validation

Local checks run before opening this PR:

- `python3 .github/generate.py --validate`
- `validate_links.py` check for the new file (`plugins/bernardopg-adguard-vpn.json`)

CI will run full repository validation for all plugins/themes.

