### PR TITLE
Update displayOutput plugins (Simplify features & add socat dependency)

### DIFF
--- a/plugins/xyzsteven-displayoutput.json
+++ b/plugins/xyzsteven-displayoutput.json
@@ -5,8 +5,8 @@
     "category": "system",
     "repo": "https://github.com/xyzsteven/dms-displayoutput",
     "author": "xyzsteven",
-    "description": "A Hyprland DankMaterialShell plugin that allows you to manage your display outputs (PC Only, Mirror, Extend, Second Screen Only).",
-    "dependencies": [],
+    "description": "Manage display outputs (Single Display, Mirror, Extend).",
+    "dependencies": ["socat"],
     "compositors": ["hyprland"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/xyzsteven/dms-displayoutput/refs/heads/main/screenshot.png"


### PR DESCRIPTION
### Description
This PR updates the `displayOutput` plugin to reflect the latest major feature additions in the source repository.

**Changes:**
- Added `"socat"` to the `dependencies` array. This is required for the new background socket watcher that dynamically listens to Hyprland hardware events for the smart auto-fallback feature.
- Verified that the `id` and `name` fields still strictly match the source repository's `plugin.json`.

All local validations (`generate.py --validate` and `validate_links.py`) have passed successfully.