### PR TITLE
Add TeamSpeak widget to registry

### DIFF
--- a/plugins/thisilike-teamspeak-status.json
+++ b/plugins/thisilike-teamspeak-status.json
@@ -7,7 +7,7 @@
     "author": "thisilike",
     "description": "Real-time TeamSpeak 6 status display — server, channel, mute, talking, away",
     "dependencies": ["ts-status"],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/thisilike/dms-plugin-teamspeak/master/screenshot.png"
 }


### PR DESCRIPTION
# Add TeamSpeak bar widget

I created this widget for displaying my TeamSpeak status. 
It should work for TS5 and TS6+.

<img width="430" height="264" alt="image" src="https://github.com/user-attachments/assets/e82e94c2-9ab9-4c82-a55c-c2fa846f4abb" />

## Key Features
- Server name and connection status
- Current channel name with auto-scrolling
- Microphone/speaker mute icons with priority logic
- Talking indicator dot
- Away status icon
- Multi-server badge when connected to multiple servers
- Channel member list in popout with per-user mute/talking/away indicators

All test's run through without problem. Just some of other plugins are broken...

It also has settings making it possible to customize if needed.

<img width="527" height="836" alt="image" src="https://github.com/user-attachments/assets/a57b9f9a-eb16-4bd1-8a84-298329a4b5d6" />