### PR TITLE
Add Volume Mixer plugin

### DIFF
--- a/plugins/cwelsys-volume-mixer.json
+++ b/plugins/cwelsys-volume-mixer.json
@@ -1,0 +1,20 @@
+{
+  "id": "volumeMixer",
+  "name": "Volume Mixer",
+  "description": "Standalone volume mixer for your bar",
+  "version": "1.0.0",
+  "author": "cwel",
+  "repo": "https://github.com/cwelsys/dms-volume-mixer",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "dependencies": [],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/cwelsys/dms-volume-mixer/main/assets/screenshot.png"
+}


### PR DESCRIPTION
It's a volume mixer, similar to the one that lives in Control Center underneath the output device, just standalone. Also allows for adjusting volume level above 100%. 

2 clicks and some scrolling was becoming too cumbersome for me so I figured id just put it up on the bar as its own thing.

generate --validate and validate_links passed.