### PR TITLE
Add CodexBar plugin registry entry

### DIFF
--- a/plugins/zakstam-codexbar.json
+++ b/plugins/zakstam-codexbar.json
@@ -1,0 +1,13 @@
+{
+  "id": "codexBar",
+  "name": "CodexBar",
+  "capabilities": ["dankbar-widget"],
+  "category": "monitoring",
+  "repo": "https://github.com/zakstam/dms-codexbar",
+  "author": "zak",
+  "description": "Monitor AI provider usage quotas",
+  "dependencies": [],
+  "compositors": ["niri", "hyprland"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/zakstam/dms-codexbar/main/screenshot.png"
+}


### PR DESCRIPTION
  ## Summary
  Adds a new plugin entry for **CodexBar** to the plugin registry.

  ## Plugin
  - **id:** `codexBar`
  - **name:** `CodexBar`
  - **repo:** https://github.com/zakstam/dms-codexbar
  - **category:** `monitoring`
  - **capabilities:** `["dankbar-widget"]`
  - **compositors:** `["niri", "hyprland"]`
  - **distro:** `["any"]`

  ## Description
  CodexBar monitors AI provider usage quotas (Claude, Codex, Gemini, Copilot, etc.) and displays usage in DankBar with an
  expandable detailed view.

  ## Validation
  Ran locally:
  - `python3 .github/generate.py --validate` ✅
  - `python3 .github/validate_links.py` shows this new entry as ✅ (`zakstam-codexbar.json`), with unrelated pre-existing
  failures in other plugin entries due to external link/API issues.