### PR TITLE
Show Desktop bar icon (hyprland)

### DIFF
--- a/plugins/lpv11-dms-hypr-show-desktop.json
+++ b/plugins/lpv11-dms-hypr-show-desktop.json
@@ -1,0 +1,19 @@
+{
+  "id": "showDesktop",
+  "name": "Show Desktop",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/lpv11/dms-hypr-show-desktop",
+  "author": "lpv11",
+  "description": "Clickable bar icon that adds windows-life show desktop function. For Hyprland.",
+  "dependencies": [],
+  "compositors": [
+    "hyprland"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/lpv11/dms-hypr-show-desktop/main/screenshot.png"
+}


### PR DESCRIPTION
A hyprland only script that adds a windows-like show desktop function as a clickable icon.
Also `dms ipc call hypr toggleOverview` as a possible secondary action (right-click for example).

The only problem with this plugin is the only way to bring back the hidden windows is by clicking the show desktop widget again. So it's not a 100% windows show desktop clone. It's not possible to do it without touching other files and user's keybinds probably (I think).
