### PR TITLE
Add Canvas Grades plugin by mcwiseman97

### DIFF
--- a/plugins/mcwiseman97-canvasgrades.json
+++ b/plugins/mcwiseman97-canvasgrades.json
@@ -1,0 +1,14 @@
+{
+    "id": "canvasGrades",
+    "name": "Canvas Grades",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/mcwiseman97/dms-canvas-plugin",
+    "path": "canvasGrades",
+    "author": "mcwiseman97",
+    "description": "Courses, grades, upcoming assignments, missing work, and announcements from Canvas LMS",
+    "dependencies": ["curl", "jq", "bash"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/mcwiseman97/dms-canvas-plugin/main/screenshots/canvas-popout.png"
+}


### PR DESCRIPTION
## Canvas Grades

A DankBar widget that shows Canvas LMS grades, upcoming assignments, missing work, and announcements.

**Features:**
- At-a-glance stat tiles (Upcoming / Missing / Announcements)
- Live grade strip with all course grades, clickable to open Canvas
- Assignments grouped by due date: TODAY / TOMORROW / THIS WEEK / LATER
- Assignment type icons (quiz, discussion, reading) with semantic colors
- Mark Done button for completion-type assignments
- Auto-refresh with configurable interval

**Dependencies:** `curl`, `jq`, `bash`
**Compositors:** niri, hyprland
**Distro:** any