### PR TITLE
Add Audio Switcher plugin

### DIFF
--- a/plugins/cd-z-audio-switcher.json
+++ b/plugins/cd-z-audio-switcher.json
@@ -1,0 +1,13 @@
+{
+  "id": "audioSwitcher",
+  "name": "Audio Switcher",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/CD-Z/dms-plugins",
+  "author": "CD-Z",
+  "description": "Quickly toggle between different audio output devices",
+  "dependencies": [],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/CD-Z/dms-plugins/master/settings.png"
+}


### PR DESCRIPTION
This is a simple plugin adding a bar widget to quickly switch between two predefined audio outputs.

## Use case

People often have multiple Audio outputs in their pc. For example: A headset, Stereo speakers, gamepad, Monitor and some other virtual outputs. Usually they only need one or two of these.

So with this widget they can just quickly switch between them without going through menus and searching for the right audio output when a dc call comes in.