### PR TITLE
Add Canvas Grades plugin by mcwiseman97

### DIFF
--- a/plugins/mcwiseman97-canvasGrades.json
+++ b/plugins/mcwiseman97-canvasGrades.json
@@ -1,0 +1,14 @@
+{
+    "id": "canvasGrades",
+    "name": "Canvas Grades",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/mcwiseman97/dms-canvas-plugin",
+    "path": "canvasGrades",
+    "author": "mcwiseman97",
+    "description": "Courses, grades, upcoming assignments, missing work, and announcements from Canvas LMS",
+    "dependencies": ["curl", "jq", "bash"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/mcwiseman97/dms-canvas-plugin/main/screenshots/canvas-popout.png"
+}


### PR DESCRIPTION
Adds the Canvas Grades plugin (`canvasGrades`) which displays courses, grades, upcoming assignments, missing work, and announcements from Canvas LMS.

- **Author:** mcwiseman97
- **Compositors:** Niri, Hyprland
- **Dependencies:** curl, jq, bash
- **Category:** utilities