### PR TITLE
Add qCal Calendar plugin

### DIFF
--- a/plugins/szabolcsf-qcal-calendar.json
+++ b/plugins/szabolcsf-qcal-calendar.json
@@ -8,5 +8,6 @@
     "description": "CalDAV calendar with events, notifications, and event management. Works with iCloud, Google, Nextcloud, and any CalDAV server.",
     "dependencies": ["python3", "go"],
     "compositors": ["any"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://github.com/szabolcsf/dms-qcal-calendar/raw/main/screenshot.png"
 }


### PR DESCRIPTION
## Summary
- Adds **qCal Calendar** — a CalDAV calendar widget with event management, notifications, and multi-provider support
- Works with iCloud, Google, Nextcloud, and any CalDAV server
- Includes GNOME Keyring integration for secure credential storage

## Screenshot
![screenshot](https://github.com/szabolcsf/dms-qcal-calendar/raw/main/screenshot.png)