### PR TITLE
Add Audio Slots plugin

### DIFF
--- a/plugins/lpv11-dms-audio-slots.json
+++ b/plugins/lpv11-dms-audio-slots.json
@@ -7,7 +7,7 @@
     "author": "lpv11",
     "description": "Daemon plugin for cycling saved output/input device slots and toggling focused-app mute via DMS IPC.",
     "dependencies": ["pactl", "awk"],
-    "compositors": ["hyprland", "niri"],
+    "compositors": ["hyprland"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/lpv11/dms-audio-slots/main/screenshot.png"
 }


### PR DESCRIPTION
It's a daemon plugin that adds `dms ipc` calls for switching audio output/input device and toggling focused app mute. 🙏