### PR TITLE
Add Taskwarrior plugin

### DIFF
--- a/plugins/cyrylas-taskwarrior.json
+++ b/plugins/cyrylas-taskwarrior.json
@@ -1,8 +1,7 @@
 {
   "id": "taskwarrior",
   "name": "Taskwarrior",
-  "description": "Taskwarrior integration for DMS: see your pending tasks in the status bar, create new tasks using
-  Taskwarrior syntax, and check them off with a single click",
+  "description": "Taskwarrior integration for DMS: see your pending tasks in the status bar, create new tasks using Taskwarrior syntax, and check them off with a single click",
   "category": "utilities",
   "repo": "https://github.com/cyrylas/dms-taskwarrior",
   "author": "Michał Wazgird",


### PR DESCRIPTION
This plugin integrates [taskwarrior](https://taskwarrior.org) into a widget.
You can:
* see most urgent tasks
* mark tasks done
* create new tasks

Requirements:
* taskwarrior installed locally (for `task` command).

![Screenshot](https://raw.githubusercontent.com/cyrylas/dms-taskwarrior/master/screenshots/screenshot-dark.png)