### PR TITLE
Add Unified Taskbar plugin

### DIFF
--- a/plugins/jslandau-unified-taskbar.json
+++ b/plugins/jslandau-unified-taskbar.json
@@ -1,0 +1,13 @@
+{
+    "id": "unifiedTaskbar",
+    "name": "Unified Taskbar",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/jslandau/dms-unified-taskbar",
+    "author": "Joshua Landau",
+    "description": "Running apps grouped by workspace with per-workspace pills",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/jslandau/dms-unified-taskbar/master/screenshot.png"
+}


### PR DESCRIPTION
Unified Taskbar is a workspace-grouped taskbar widget showing running apps organized by workspace with per-workspace pills.  (Basically combining WorkspaceSwitcher and RunningApps, as discussed in issue [1207](https://github.com/AvengeMedia/DankMaterialShell/issues/1207).) 

Should support all compositors (tested only on Niri).