### PR TITLE
Add Screen Recorder plugin by arqueon

### DIFF
--- a/plugins/arqueon-screenrecorder.json
+++ b/plugins/arqueon-screenrecorder.json
@@ -9,6 +9,6 @@
   "dependencies": ["gpu-screen-recorder", "xdg-desktop-portal-gnome"],
   "compositors": ["any"],
   "distro": ["any"],
-  "screenshot": "https://raw.githubusercontent.com/arqueon/dms-screen-recorder/master/assets/screenshot.png",
+  "screenshot": "https://raw.githubusercontent.com/arqueon/dms-screen-recorder/main/assets/screenshot.png",
   "requires_dms": ">=1.2.0"
 }


### PR DESCRIPTION
Adding the screenRecorder plugin to the registry. Repository: https://github.com/arqueon/dms-screen-recorder