### PR TITLE
Add gameControllerBattery plugin for battery monitoring

### DIFF
--- a/plugins/hujair-gamecontrollerbattery
+++ b/plugins/hujair-gamecontrollerbattery
@@ -1,0 +1,13 @@
+{
+"id": "gameControllerBattery",
+"name": "Game Controller Battery",
+"capabilities": ["dankbar-widget"],
+"category": "monitoring",
+"repo": "https://github.com/Hujair/gameControllerBattery",
+"author": "Mohammad Hujair",
+"description": "Shows the battery level of connected game controllers",
+"dependencies": ["upower"],
+"compositors": ["niri", "hyprland"],
+"distro": ["any"],
+"screenshot": "https://raw.githubusercontent.com/Hujair/gameControllerBattery/v1.0.0/dms-screenshot-1773854869435.png"
+}


### PR DESCRIPTION
a plugin to monitor the battery level of connected game controllers and provides relevant information.

Features :
- controller name
- battery level 
- charging / discharging status 
- battery low warning

![dms-screenshot-1773854869435.png](https://github.com/user-attachments/assets/8d173973-a59c-4eb1-b269-2dc5b9ecaffb)

