### PR TITLE
Add Simple Audio Control plugin

### DIFF
--- a/plugins/dadangdut33-simpleaudiocontrol.json
+++ b/plugins/dadangdut33-simpleaudiocontrol.json
@@ -10,5 +10,5 @@
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/SimpleAudioControl/preview/widget.png"
+    "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/SimpleAudioControl/preview/tab-1.png"
 }


### PR DESCRIPTION
I made a plugin to make it easier to control audio in the bar by using this widget / plugin. With this plugin, we dont need to click on the control center widget everytime when we want to set a volume for certain output / apps or when we want to switch device output

The design for this is heavily inspired by the audio widget in noctalia shell.