### PR TITLE
Add Netbird Status plugin

### DIFF
--- a/plugins/dadangdut33-netbirdstatus.json
+++ b/plugins/dadangdut33-netbirdstatus.json
@@ -1,6 +1,6 @@
 {
     "id": "netbirdStatus",
-    "name": "Netbird Status",
+    "name": "NetBird Status",
     "capabilities": ["dankbar-widget"],
     "category": "utilities",
     "repo": "https://github.com/Dadangdut33/dms-plugins",


### PR DESCRIPTION
I created / ported a plugin from Noctalia plugins to show Netbird Status. 
It works very simple by utilizing the cli from netbird and then parsing the data into the widget.