### PR TITLE
feat: add displayProfile plugin by EienWolf

### DIFF
--- a/plugins/eienwolf-dms-displayprofile.json
+++ b/plugins/eienwolf-dms-displayprofile.json
@@ -1,0 +1,12 @@
+{
+    "id": "displayProfile",
+    "name": "Display Profile",
+    "capabilities": [],
+    "category": "utilities",
+    "repo": "https://github.com/EienWolf/dms-displayprofile",
+    "author": "EienWolf",
+    "description": "Switch between saved Hyprland display profiles from a keyboard-driven modal.",
+    "dependencies": [],
+    "compositors": ["hyprland"],
+    "distro": ["any"]
+}

--- a/plugins/eienwolf-dms-displayprofile.json
+++ b/plugins/eienwolf-dms-displayprofile.json
@@ -8,5 +8,6 @@
     "description": "Switch between saved Hyprland display profiles from a keyboard-driven modal.",
     "dependencies": [],
     "compositors": ["hyprland"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/EienWolf/dms-displayprofile/refs/heads/master/screenshot.png"
 }


### PR DESCRIPTION
## New Plugin Submission

Adds the **Display Profile** plugin to the registry.

| Field | Value |
|-------|-------|
| Plugin ID | `displayProfile` |
| Author | EienWolf |
| Compositor | Hyprland |
| Category | utilities |
| Repo | https://github.com/EienWolf/dms-displayprofile |

## Description

Keyboard-driven modal for switching between saved Hyprland display profiles. Integrates with DMS via IPC (`dms ipc call displayProfile toggle/open/close`).