### PR TITLE
feat: add dms-mpvpaper

### DIFF
--- a/plugins/kanghengliu-dms-mpvpaper.json
+++ b/plugins/kanghengliu-dms-mpvpaper.json
@@ -1,0 +1,13 @@
+{
+    "id": "mpvpaperWallpaper",
+    "name": "mpvpaper Video Wallpaper",
+    "capabilities": ["wallpaper", "animation", "dankbar-widget"],
+    "category": "appearance",
+    "repo": "https://github.com/kanghengliu/dms-mpvpaper",
+    "author": "kanghengliu",
+    "description": "Video wallpaper support using mpvpaper",
+    "dependencies": ["mpvpaper"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/kanghengliu/dms-mpvpaper/main/screenshot.png"
+}


### PR DESCRIPTION
The PR adds dms-mpvpaper plugin to enable setting video as wallpapers with `mpvpaper`. 
## Features
- Per-monitor wallpaper configuration
- Color generation with matugen
- Periodic restart of mpvpaper process
- Custom mpv options
- Widget in dankbar