### PR TITLE
Add USB Manager plugin

### DIFF
--- a/plugins/nordicssys-dms-usb-manager.json
+++ b/plugins/nordicssys-dms-usb-manager.json
@@ -1,0 +1,14 @@
+{
+    "id": "usbManager",
+    "name": "USB Manager",
+    "capabilities": ["dankbar-widget", "notify"],
+    "category": "system",
+    "repo": "https://github.com/NordicsSys/dms-usb-manager",
+    "author": "NordicsSys",
+    "description": "Bar widget: monitor removable USB drives, mount/unmount, eject, format (FAT32/exFAT/ext4), resize partitions; notifications on plug/unplug via udisks.",
+    "dependencies": ["udisks2", "bash", "lsblk", "parted", "dosfstools", "e2fsprogs", "exfatprogs", "polkit"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/NordicsSys/dms-usb-manager/main/assets/screenshot.png",
+    "requires_dms": ">=1.2.0"
+}


### PR DESCRIPTION
## USB Manager

Adds registry entry for third-party plugin **USB Manager** (`usbManager`).

- **Repository:** https://github.com/NordicsSys/dms-usb-manager
- **Category:** system
- **Capabilities:** `dankbar-widget`, `notify`
- **Description:** Bar widget for removable USB drives: mount/unmount, eject, format (FAT32/exFAT/ext4), resize partitions; plug/unplug notifications via udisks.

`plugin.json` `id` and `name` match the upstream plugin repo. Screenshot and repo URLs validated against `main`.