### PR TITLE
Add Hebrew Calendar (hebcalDate) plugin

### DIFF
--- a/plugins/hatt-io-hebcal-date.json
+++ b/plugins/hatt-io-hebcal-date.json
@@ -1,0 +1,12 @@
+{
+    "id": "hebcalDate",
+    "name": "Hebrew Calendar",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hatt-io/dms-hebcal-date",
+    "author": "hatt-io",
+    "description": "Display the current Hebrew date and parsha using hebcal",
+    "dependencies": ["hebcal"],
+    "compositors": ["any"],
+    "distro": ["any"]
+}


### PR DESCRIPTION
Adds a Hebrew Calendar widget for DankBar that displays the current Hebrew date and weekly Torah portion (parsha) using hebcal.

**Features:**
- Displays Hebrew date in the bar
- Shows weekly parsha (toggleable)
- 16 transliteration/language options (Ashkenazi Litvish/Standard/Poylish/Romanian, Sephardic, Hebrew, German, Spanish, Finnish, French, Hungarian, Polish, Romanian, Russian, Ukrainian)
- Horizontal and vertical bar support

**Dependencies:** hebcal

**Plugin repo:** https://github.com/hatt-io/dms-hebcal-date