### PR TITLE
Add clipboard+ plugin

### DIFF
--- a/plugins/dadangdut33-clipboardplus.json
+++ b/plugins/dadangdut33-clipboardplus.json
@@ -1,0 +1,14 @@
+{
+    "id": "clipboardPlus",
+    "name": "ClipBoard+",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Dadangdut33/dms-plugins",
+    "path": "ClipboardPlus",
+    "author": "Dadangdut33",
+    "description": "Advanced clipboard manager with integrated notes, todo, and pinned items.",
+    "dependencies": ["cliphist", "wl-clipboard"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/ClipboardPlus/preview/preview-blur.png"
+}


### PR DESCRIPTION
Created a clipboard plugin that is a forked / inspired by clipper plugin in noctalia

## Features available

- Clipboard with categorization
- Add clipboard to ToDo
- Pinned clipboard
- Notes
- Keyboard navigation
- hide widget from bar
- call from ipc
- many customizations

## Preview

![preview](https://raw.githubusercontent.com/Dadangdut33/dms-plugins/refs/heads/master/ClipboardPlus/preview/preview-blur.png)