### PR TITLE
Add awcc plugin

### DIFF
--- a/plugins/psyreactor-awcc.json
+++ b/plugins/psyreactor-awcc.json
@@ -1,0 +1,14 @@
+{
+    "id": "awcc",
+    "name": "Alienware Command Center",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/psyreactor/dms-awcc",
+    "author": "psyreactor",
+    "description": "Alienware Command Center plugin for DankBar",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/psyreactor/dms-awcc/raw/main/screenshot.png",
+    "requires_dms": ">0.0.28"
+}


### PR DESCRIPTION
Alienware Command Center for control thermal modes, fan boost, keyboard lighting, light bar and turbo via awcc CLI