### PR TITLE
Add Discord Voice Widget plugin

### DIFF
--- a/plugins/pandorasfox-discord-voice.json
+++ b/plugins/pandorasfox-discord-voice.json
@@ -8,5 +8,6 @@
     "description": "Discord voice call overlay — shows participants as circular avatars with speaking/mute/deafen indicators. Supports mute/deafen keybinds and push-to-talk.",
     "compositors": ["niri", "hyprland", "sway"],
     "dependencies": ["python3"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/PandorasFox/dms-discord-widget/master/screenshot.png"
 }


### PR DESCRIPTION
## Summary
- Adds Discord voice call overlay widget for DankBar
- Shows voice channel participants as circular avatars with speaking/mute/deafen indicators
-  bonus cli surface of  `dms ipc call discord toggleMute`/`toggleDeafen`/`muteOn`/`muteOff` for toggle mute / toggle deafen / push-to-talk/mute keybinds in environments lacking global shortcuts support
- https://github.com/PandorasFox/dms-discord-widget