### PR TITLE
feat: add stvnwrgs/dms-keybindings-cheat-sheet plugin

### DIFF
--- a/plugins/stvnwrgs-keybindings-cheat-sheet.json
+++ b/plugins/stvnwrgs-keybindings-cheat-sheet.json
@@ -1,0 +1,14 @@
+{
+    "id": "keybindingCheatSheet",
+    "name": "Keybinding Cheat Sheet",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/stvnwrgs/dms-keybindings-cheat-sheet",
+    "author": "Steven Koehnke",
+    "description": "A desktop widget that parses your compositor's keybinding config and displays them as a live cheat sheet",
+    "dependencies": [],
+    "compositors": ["hyprland", "niri", "sway", "mangowc"],
+    "distro": ["any"],
+    "requires_dms": ">=1.2.0",
+    "screenshot": "https://raw.githubusercontent.com/stvnwrgs/dms-keybindings-cheat-sheet/master/example-small.png"
+}


### PR DESCRIPTION
Adds the dms-keybindings-cheat-sheet desktop widget.  

Parses your compositor's keybinding config and displays it as a live cheat sheet.
  
Supports Hyprland, Niri, Sway, and MangoWC.


```
./venv/bin/python .github/generate.py --validate
Validation successful!
```

<img width="1428" height="1348" alt="1775520128410476027" src="https://github.com/user-attachments/assets/2af9ea54-1bb9-4e3f-b921-26a56fb487d1" />


<img width="616" height="1230" alt="image" src="https://github.com/user-attachments/assets/3c46ed90-785e-4c55-b2f5-ac0fa19cde10" />
