### PR TITLE
Add DMS Agent plugin

### DIFF
--- a/plugins/francisdelca-dms-agent.json
+++ b/plugins/francisdelca-dms-agent.json
@@ -1,0 +1,21 @@
+{
+    "id": "dmsAgent",
+    "name": "DMS Agent",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/Francisdelca/dms-agent",
+    "author": "Francisdelca (Francis)",
+    "description": "AI desktop assistant powered by Claude Code. Floating chat panel for controlling your desktop with natural language — open apps, switch windows, play music, search the web, and more.",
+    "dependencies": [
+        "claude"
+    ],
+    "compositors": [
+        "niri"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/Francisdelca/dms-agent/main/screenshots/panel.png"
+}


### PR DESCRIPTION
## Summary

- Adds **DMS Agent** — AI desktop assistant plugin powered by Claude Code
- Floating transparent chat panel for controlling the desktop with natural language
- Open apps, switch windows, play music, search the web, manage files, and more

## Plugin Details

- **Repo**: https://github.com/Francisdelca/dms-agent
- **Compositor**: niri
- **Dependencies**: Claude Code CLI (`claude`)

## Screenshots

### Full desktop view
![Overview](https://raw.githubusercontent.com/Francisdelca/dms-agent/main/screenshots/overview.png)

### Panel close-up
![Panel](https://raw.githubusercontent.com/Francisdelca/dms-agent/main/screenshots/panel.png)

## Features

- Claude Code integration with full tool access (Bash, Read, Write, Edit)
- Session persistence and history
- Model selector (Haiku/Sonnet/Opus) with extended thinking toggle
- Cost tracking per response
- Intent detection for common desktop actions
- Theme-aware UI with Markdown rendering
- Keyboard toggle (Super+A)