### PR TITLE
Add Image Converter plugin

### DIFF
--- a/plugins/murilo-gotardo-image-converter.json
+++ b/plugins/murilo-gotardo-image-converter.json
@@ -1,0 +1,13 @@
+{
+    "id": "imageConverter",
+    "name": "ImageConverter",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/murilo-gotardo/dms-image-converter",
+    "author": "Murilo",
+    "description": "Convert images between formats (PNG, JPG, WEBP, BMP, TIFF) from the DankBar",
+    "dependencies": ["imagemagick", "wl-clipboard"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Murilo-Gotardo/dms-image-converter/refs/heads/main/screenshots/converter.png"
+}


### PR DESCRIPTION
A DankBar widget plugin for converting images between formats (PNG, JPG, WEBP, BMP, TIFF) using ImageMagick. Users can select a file, choose the output format, adjust quality for lossy formats, and convert directly from the bar popout.