### PR TITLE
Add dankRazer — Razer Device Manager

### DIFF
--- a/plugins/zachfi-dms-razer.json
+++ b/plugins/zachfi-dms-razer.json
@@ -8,6 +8,7 @@
   ],
   "category": "utilities",
   "repo": "https://github.com/zachfi/dms-razer",
+  "screenshot": "https://raw.githubusercontent.com/zachfi/dms-razer/main/screenshot.png",
   "author": "zachfi",
   "description": "Control Razer peripherals via OpenRazer — lighting effects, brightness, DPI, and battery monitoring",
   "dependencies": [

--- a/plugins/zachfi-dms-razer.json
+++ b/plugins/zachfi-dms-razer.json
@@ -1,0 +1,21 @@
+{
+  "id": "dankRazer",
+  "name": "Razer Device Manager",
+  "capabilities": [
+    "dankbar-widget",
+    "control-center",
+    "command-execution"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/zachfi/dms-razer",
+  "author": "zachfi",
+  "description": "Control Razer peripherals via OpenRazer — lighting effects, brightness, DPI, and battery monitoring",
+  "dependencies": [
+    "openrazer-daemon",
+    "go"
+  ],
+  "compositors": ["any"],
+  "distro": [
+    "any"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `dankRazer` plugin for controlling Razer peripherals via OpenRazer
- Brightness, DPI, lighting effects (static, wave, spectrum), battery monitoring
- Auto lights-off on screen lock/sleep/idle with restore on wake
- Multi-device sync support
- Requires `openrazer-daemon` and `go` (to build the CLI binary)

**Repository:** https://github.com/zachfi/dms-razer
**Release:** https://github.com/zachfi/dms-razer/releases/tag/v0.2.0