### PR TITLE
Add Next Boot Selector plugin

### DIFF
--- a/plugins/arcatva-nextbootselector.json
+++ b/plugins/arcatva-nextbootselector.json
@@ -1,0 +1,13 @@
+{
+    "id": "nextBootSelector",
+    "name": "Next Boot Selector",
+    "capabilities": ["dankbar-widget", "control-center"],
+    "category": "system",
+    "repo": "https://github.com/arcatva/dms-next-boot-selector",
+    "author": "arcatva",
+    "description": "Pick which EFI boot entry to load on next reboot via efibootmgr. Bar pill + Control Center widget with a scrollable picker.",
+    "dependencies": ["efibootmgr", "sudo"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/arcatva/dms-next-boot-selector/main/screenshots/popout.png"
+}


### PR DESCRIPTION
## Summary

Adds **Next Boot Selector**, a plugin that lets users pick which EFI boot entry `efibootmgr --bootnext` will load on the next reboot, from either the DankBar or Control Center.

- **Repo:** https://github.com/arcatva/dms-next-boot-selector
- **License:** MIT
- **Capabilities:** `dankbar-widget`, `control-center`
- **Category:** `system`
- **Dependencies:** `efibootmgr`, `sudo` (a NOPASSWD sudoers snippet is included in the repo, scoped to only `efibootmgr --bootnext XXXX` and `efibootmgr --delete-bootnext`)

## UI

- **Bar pill:** single `restart_alt` icon, tints primary when a BootNext is pending.
- **CC widget:** compound pill showing the pending target, with a scrollable picker detail that keeps Clear / Reboot actions pinned at the bottom.
- State is shared across plugin instances via `PluginService.setGlobalVar` so the CC detail (which is instantiated without a `pluginId` and therefore can't use `pluginData` / `PluginGlobalVar`) stays reactive.

Screenshots are in the plugin repo at `screenshots/popout.png` and `screenshots/control-center.png`. The registry entry references the popout one.

## Validation

- ✅ `python3 .github/generate.py --validate`
- ✅ `python3 .github/validate_links.py` (run scoped to the new entry with `GITHUB_TOKEN` set)
- ✅ `id` (`nextBootSelector`) and `name` (`Next Boot Selector`) match the repo's `plugin.json`
- ✅ No duplicate `id` / `name` in existing registry