### PR TITLE
feat: add Trash Bin plugin by kerojiang

### DIFF
--- a/plugins/kero-trashbin.json
+++ b/plugins/kero-trashbin.json
@@ -1,0 +1,13 @@
+{
+    "id": "trashBin",
+    "name": "Trash Bin",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/kerojiang/dms-transBin",
+    "author": "kerojiang",
+    "description": "Monitor and manage your system trash directly from your status bar. Features real-time monitoring, quick access, empty trash button, and auto-clean configuration.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/kerojiang/dms-transBin/refs/heads/main/images/bin-full.png"
+}


### PR DESCRIPTION
Summary

1 Adds transBin, a DankBar widget that monitors and manages system trash directly from your status bar
2 Zero dependencies, works on any desktop environment with FreeDesktop.org trash support
3 Plugin repo: https://github.com/kerojiang/dms-transBin