### PR TITLE
Add UPS Monitor Plugin

### DIFF
--- a/plugins/acmagn-dankupsmonitor.json
+++ b/plugins/acmagn-dankupsmonitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankUpsMonitor",
+    "name": "Dank UPS Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/acmagn/DMS-UPS-Monitor",
+    "author": "acmagn",
+    "description": "Real-time UPS status via NUT (upsc) for the DankBar: on-battery styling, optional desktop notifications, and a charge history graph in the popout",
+    "dependencies": ["upsc"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/user-attachments/assets/06f0f507-67b4-452a-b4f8-ad37ac80a795"
+}

--- a/plugins/acmagn-dankupsmonitor.json
+++ b/plugins/acmagn-dankupsmonitor.json
@@ -9,5 +9,5 @@
     "dependencies": ["upsc"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://github.com/user-attachments/assets/06f0f507-67b4-452a-b4f8-ad37ac80a795"
+    "screenshot": "https://github.com/acmagn/DMS-UPS-Monitor/blob/main/assets/screenshot.png"
 }

--- a/plugins/acmagn-dankupsmonitor.json
+++ b/plugins/acmagn-dankupsmonitor.json
@@ -5,7 +5,7 @@
     "category": "monitoring",
     "repo": "https://github.com/acmagn/DMS-UPS-Monitor",
     "author": "acmagn",
-    "description": "Real-time UPS status via NUT (upsc) for the DankBar: on-battery styling, optional desktop notifications, and a charge history graph in the popout",
+    "description": "Real-time UPS status widget via NUT (upsc).",
     "dependencies": ["upsc"],
     "compositors": ["any"],
     "distro": ["any"],


### PR DESCRIPTION
A DankBar widget plugin for UPS monitoring via upsc. Displays UPS info (with drop-down for more info).

Users can configure what UPS info is displayed in the bar, optional UPS battery history, notification settings, and thresholds for widget to display "warning" and "critical" states in bar.