### PR TITLE
add DankPinentry plugin

### DIFF
--- a/plugins/pacman99-dank-pinentry.json
+++ b/plugins/pacman99-dank-pinentry.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankPinentry",
+    "name": "DankPinentry",
+    "capabilities": ["authentication", "ipc", "daemon"],
+    "category": "utilities",
+    "repo": "https://github.com/pacman99/DankPinentry",
+    "path": "plugin",
+    "author": "Parthiv Seetharaman",
+    "description": "GPG/SSH passphrase entry with native DMS modal.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Pacman99/DankPinentry/refs/heads/master/screenshot.png"
+}


### PR DESCRIPTION
Pinentry implementation that displays a native DMS prompt for passphrase entry. Works with GPG, SSH, and RBW (Bitwarden CLI).
<img width="678" height="293" alt="image" src="https://github.com/user-attachments/assets/3f349b60-0bb1-43ed-8dfc-652f5e0c3df8" />

