### PR TITLE
Add media control plus plugin

### DIFF
--- a/plugins/dadangdut33-mediacontrolplus.json
+++ b/plugins/dadangdut33-mediacontrolplus.json
@@ -1,0 +1,14 @@
+{
+    "id": "mediaControlPlus",
+    "name": "Media Control Plus",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Dadangdut33/dms-plugins",
+    "path": "MediaControlPlus",
+    "author": "Dadangdut33",
+    "description": "Customized version of DMS media widget with extended features that is mainly focused on improving vertical bar support",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/MediaControlPlus/preview/vertical.png"
+}


### PR DESCRIPTION
A simple extended version of the default media widget from DMS with mainly improved support for vertical layouts while also adding more control over the widgets.

## Features

- Improved Vertical layout settings
  - Can show title in vertical layout, complete with scrollable text option, and optional backdrop behind the title
  - Can set max height for title area in vertical layout
  - Can show next/previous buttons in vertical layout
- Rearrangable widget elements in both horizontal and vertical layouts
- Visualizer settings for both horizontal and vertical layouts
- Rotated visualizer for vertical layout
- Settings for visualizer bar count and width / height
- Settings for visualizer position (top, center, bottom)
- New visualizer style (dotted and line style)
- Option to change the listener for the visualizer to all audio instead of just the media player
- Optional popout size settings for both the horizontal and vertical layouts
- Optional extra backdrop panel behind the media content
- Optional use of the track artwork as a blurred backdrop for the popout content

![dotted](https://raw.githubusercontent.com/Dadangdut33/dms-plugins/refs/heads/master/MediaControlPlus/preview/dotted-style.png)

![dotted 2](https://raw.githubusercontent.com/Dadangdut33/dms-plugins/refs/heads/master/MediaControlPlus/preview/dotted-style-2.png)

![Preview Vertical](https://raw.githubusercontent.com/Dadangdut33/dms-plugins/refs/heads/master/MediaControlPlus/preview/vertical.png)

![preview visualizer only](https://raw.githubusercontent.com/Dadangdut33/dms-plugins/refs/heads/master/MediaControlPlus/preview/visualizer-only.png)

![Preview Horizontal](https://raw.githubusercontent.com/Dadangdut33/dms-plugins/refs/heads/master/MediaControlPlus/preview/horizontal.png)