### PR TITLE
Add DMS Desktop Countdown plugin

### DIFF
--- a/plugins/nfoert-dmsdesktopcountdown.json
+++ b/plugins/nfoert-dmsdesktopcountdown.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsDesktopCountdown",
+    "name": "DMS Desktop Countdown",
+    "capabilities": ["desktop"],
+    "category": "utilities",
+    "repo": "https://github.com/nfoert/dms-desktop-countdown",
+    "author": "nfoert",
+    "description": "Allows creating desktop widget countdowns with progress, view options, and the ability to only count certain days in a week",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/nfoert/dms-desktop-countdown/blob/main/repo/images/image.png?raw=true"
+}


### PR DESCRIPTION
This plugin allows for creating simple desktop widget countdowns, to help keep track of upcoming dates or project deadlines

- Count the days until an end date
- Provide a start date to get progress from then until the end date
- Display the hours, days, and weeks until the end date
- Only count certain days of the week, like how many Mondays until the end date