### PR TITLE
Add DankDiskUsage plugin

### DIFF
--- a/plugins/alcxyz-dank-disk-usage.json
+++ b/plugins/alcxyz-dank-disk-usage.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankDiskUsage",
+    "name": "Disk Usage",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/alcxyz/DankDiskUsage",
+    "author": "alcxyz",
+    "description": "Monitor disk, ZFS pool, and Nix store usage with smart mount classification and expandable ZFS pool detail",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankDiskUsage/main/docs/screenshot.png"
+}


### PR DESCRIPTION
## Summary

- Adds DankDiskUsage, a DankBar widget for monitoring disk, ZFS pool, and Nix store usage
- Smart mount classification prioritizes system paths (/, /home, /nix, /var, /boot)
- ZFS datasets grouped by pool with expandable detail
- Bar pill shows the most relevant system mount percentage

## Plugin info

- **id:** `dankDiskUsage`
- **category:** monitoring
- **capabilities:** dankbar-widget
- **repo:** https://github.com/alcxyz/DankDiskUsage
- **compositors:** any
- **distro:** any
- **dependencies:** none