### PR TITLE
Add DankCalendar plugin

### DIFF
--- a/plugins/alcxyz-dank-calendar.json
+++ b/plugins/alcxyz-dank-calendar.json
@@ -9,5 +9,5 @@
     "dependencies": ["secret-tool", "notify-send"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankCalendar/main/docs/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankCalendar/v0.4.0/docs/screenshot.png"
 }

--- a/plugins/alcxyz-dank-calendar.json
+++ b/plugins/alcxyz-dank-calendar.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankCalendar",
+    "name": "DankCalendar",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/alcxyz/DankCalendar",
+    "author": "alcxyz",
+    "description": "CalDAV calendar widget with event listing, notifications, and event management via a stdlib-only Go binary with keyring credentials",
+    "dependencies": ["secret-tool", "notify-send"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankCalendar/main/docs/screenshot.png"
+}


### PR DESCRIPTION
## Summary

- Adds `plugins/alcxyz-dank-calendar.json` for [DankCalendar](https://github.com/alcxyz/DankCalendar)
- CalDAV calendar dankbar-widget — single Go binary (stdlib-only), keyring credentials via `secret-tool`, desktop notifications via `notify-send`
- Follows the same conventions as the existing alcxyz plugin entries

## Test plan

- [ ] JSON is valid and all required fields are present
- [ ] `id` matches `plugin.json` (`dankCalendar`)
- [ ] `name` matches `plugin.json` (`DankCalendar`)
- [ ] Screenshot URL is reachable
- [ ] Repo URL is public and accessible