### PR TITLE
Update screen-recorder: any compositor, IPC keybinds

### DIFF
--- a/plugins/arqueon-screenrecorder.json
+++ b/plugins/arqueon-screenrecorder.json
@@ -7,7 +7,7 @@
     "category": "utilities",
     "repo": "https://github.com/arqueon/dms-screen-recorder",
     "author": "arqueon",
-    "description": "Start, stop, and configure screen captures with gpu-screen-recorder (Wayland: niri, Hyprland, etc.)",
+    "description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor. Supports IPC keybinds.",
     "dependencies": [
         "gpu-screen-recorder"
     ],


### PR DESCRIPTION
## Summary

- Remove compositor-specific language from description (`niri, Hyprland, etc.`) — the plugin works on any Wayland compositor
- Add mention of IPC keybind support (new in v1.2.0)

## Context

v1.2.0 of [arqueon/dms-screen-recorder](https://github.com/arqueon/dms-screen-recorder) fixes IPC support by moving the `IpcHandler` into an always-on launcher service component, so `dms ipc call screenRecorder toggleRecording` etc. work regardless of whether the bar widget is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)