### PR TITLE
Add AiOverviewControl plugin

### DIFF
--- a/plugins/bernardopg-aioverviewcontrol.json
+++ b/plugins/bernardopg-aioverviewcontrol.json
@@ -1,0 +1,13 @@
+{
+    "id": "aiOverviewControl",
+    "name": "AiOverviewControl",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/bernardopg/AiOverviewControl",
+    "author": "Bernardo Gomes",
+    "description": "Monitor AI subscription and API usage for Claude, Copilot, Codex, Gemini, and OpenRouter from DankBar",
+    "dependencies": ["bash", "jq", "curl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/bernardopg/AiOverviewControl/main/screenshot.png"
+}


### PR DESCRIPTION
## Plugin: AiOverviewControl

**Repository:** https://github.com/bernardopg/AiOverviewControl

### Description
DankBar widget that monitors AI assistant subscription and API usage in real time, aggregating data from Claude, GitHub Copilot, Codex, Gemini, and OpenRouter into a unified dashboard.

### Features
- Per-provider foldable cards with usage bars and reset timers
- Native fallback adapters for Claude Code, Copilot, Gemini, and OpenRouter (no external binary required)
- Optional `codexbar` executable for extended provider support
- Configurable provider list and source mode from the settings panel

### Validation
- `plugin.json` `id` and `name` match the registry entry exactly
- `python3 .github/generate.py --validate` → `Validation successful!`
- Screenshot URL accessible (HTTP 200)
- Tested on Arch Linux with Niri compositor

### Registry file
`plugins/bernardopg-aioverviewcontrol.json`