### PR TITLE
Add obsidian-search launcher plugin

### DIFF
--- a/plugins/kmf-obsidian-search.json
+++ b/plugins/kmf-obsidian-search.json
@@ -8,5 +8,6 @@
     "description": "Search notes in your Obsidian vaults by title, folder, and content directly from the DMS launcher",
     "dependencies": ["xdg-open"],
     "compositors": ["any"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://github.com/kmf/dms-obsidian-search/blob/main/Screenshot.png?raw=true"
 }

--- a/plugins/kmf-obsidian-search.json
+++ b/plugins/kmf-obsidian-search.json
@@ -1,0 +1,12 @@
+{
+    "id": "obsidianSearch",
+    "name": "Obsidian Vault Search",
+    "capabilities": ["launcher"],
+    "category": "utilities",
+    "repo": "https://github.com/kmf/dms-obsidian-search",
+    "author": "kmf",
+    "description": "Search notes in your Obsidian vaults by title, folder, and content directly from the DMS launcher",
+    "dependencies": ["xdg-open"],
+    "compositors": ["any"],
+    "distro": ["any"]
+}


### PR DESCRIPTION
## Summary
- Adds `obsidianSearch` launcher plugin to the registry
- Searches Obsidian vault notes by title, folder, and content directly from the DMS launcher
- Repo: https://github.com/kmf/dms-obsidian-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)