### PR TITLE
feat: add Audio Output Toggle plugin

### DIFF
--- a/plugins/lelabdev-audio-output-toggle.json
+++ b/plugins/lelabdev-audio-output-toggle.json
@@ -4,7 +4,7 @@
     "capabilities": ["dankbar-widget"],
     "category": "utilities",
     "repo": "https://github.com/lelabdev/dms-plugin-audio-output",
-    "author": "Mako",
+    "author": "LoopsLudo & Mako",
     "description": "Quickly switch between audio outputs (speakers, headphones, etc.) from the DankBar with a single click",
     "dependencies": ["wireplumber", "wpctl"],
     "compositors": ["any"],

--- a/plugins/lelabdev-audio-output-toggle.json
+++ b/plugins/lelabdev-audio-output-toggle.json
@@ -1,0 +1,12 @@
+{
+    "id": "audioOutputToggle",
+    "name": "Audio Output Toggle",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/lelabdev/dms-plugin-audio-output",
+    "author": "Mako",
+    "description": "Quickly switch between audio outputs (speakers, headphones, etc.) from the DankBar with a single click",
+    "dependencies": ["wireplumber", "wpctl"],
+    "compositors": ["any"],
+    "distro": ["any"]
+}

--- a/plugins/lelabdev-audio-output-toggle.json
+++ b/plugins/lelabdev-audio-output-toggle.json
@@ -8,5 +8,6 @@
     "description": "Quickly switch between audio outputs (speakers, headphones, etc.) from the DankBar with a single click",
     "dependencies": ["wireplumber", "wpctl"],
     "compositors": ["any"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/lelabdev/dms-plugin-audio-output/refs/heads/master/assets/soundToogle.jpg"
 }


### PR DESCRIPTION
## Audio Output Toggle

Quickly switch between audio outputs (speakers, headphones, etc.) from the DankBar with a single click.

### Features
- Single click to cycle through available audio outputs
- Dynamic icon: headset for USB audio, speaker for built-in
- Toast notification on switch with output name
- Works with any number of audio outputs

### Plugin details
- **ID:** `audioOutputToggle`
- **Category:** utilities
- **Compositors:** any
- **Dependencies:** wireplumber, wpctl
- **Repo:** https://github.com/lelabdev/dms-plugin-audio-output

Validation passes: `python3 .github/generate.py --validate` ✅