### PR TITLE
Add Pangolin widget plugin

### DIFF
--- a/plugins/ricearaul-pangolin-widget.json
+++ b/plugins/ricearaul-pangolin-widget.json
@@ -1,5 +1,5 @@
 {
-    "id": "pangolinWidget",
+    "id": "pangolin-widget",
     "name": "Pangolin Widget",
     "capabilities": ["dankbar-widget", "control-center-widget"],
     "category": "network",

--- a/plugins/ricearaul-pangolin-widget.json
+++ b/plugins/ricearaul-pangolin-widget.json
@@ -1,0 +1,14 @@
+{
+    "id": "pangolinWidget",
+    "name": "Pangolin Widget",
+    "capabilities": ["dankbar-widget", "control-center-widget"],
+    "category": "network",
+    "repo": "https://github.com/RiceaRaul/DMS-PangolinPlugin",
+    "path": "",
+    "author": "Ricea Ion Raul",
+    "description": "QuickShell plugin for DankMaterialShell that exposes Pangolin VPN status, peer list with live RTT, routes, connection controls, and notifications. Backed by the pangolin CLI.",
+    "dependencies": ["pangolin"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/RiceaRaul/DMS-PangolinPlugin/blob/main/docs/screenshots/popout.png?raw=true"
+}

--- a/plugins/ricearaul-pangolin-widget.json
+++ b/plugins/ricearaul-pangolin-widget.json
@@ -1,5 +1,5 @@
 {
-    "id": "pangolin-widget",
+    "id": "pangolinWidget",
     "name": "Pangolin Widget",
     "capabilities": ["dankbar-widget", "control-center-widget"],
     "category": "network",


### PR DESCRIPTION
QuickShell plugin for DankMaterialShell that exposes Pangolin VPN status, peer list with live RTT, routes, connection controls, and notifications. Backed by the pangolin CLI.