### PR TITLE
Add Stopwatch & Timer plugin

### DIFF
--- a/plugins/hthienloc-stopwatch.json
+++ b/plugins/hthienloc-stopwatch.json
@@ -1,0 +1,13 @@
+{
+    "id": "stopwatch",
+    "name": "Stopwatch",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-stopwatch",
+    "author": "Loc Huynh",
+    "description": "Simple stopwatch widget for DankBar with start, pause, and reset controls",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-stopwatch/main/screenshot.png"
+}

--- a/plugins/hthienloc-timer.json
+++ b/plugins/hthienloc-timer.json
@@ -1,0 +1,13 @@
+{
+    "id": "timer",
+    "name": "Timer",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-timer",
+    "author": "Loc Huynh",
+    "description": "Countdown timer with presets (5-120m) and custom input",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-timer/master/screenshot.png"
+}

--- a/plugins/hthienloc-timer.json
+++ b/plugins/hthienloc-timer.json
@@ -5,7 +5,7 @@
     "category": "utilities",
     "repo": "https://github.com/hthienloc/dms-timer",
     "author": "Loc Huynh",
-    "description": "Countdown timer with presets (5-120m) and custom input",
+    "description": "Countdown timer with 9 presets (5-120m) and custom input",
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],


### PR DESCRIPTION
## Summary

- Adds `plugins/hthienloc-stopwatch.json` for [Stopwatch](https://github.com/hthienloc/dms-stopwatch)
- Adds `plugins/hthienloc-timer.json` for [Timer](https://github.com/hthienloc/dms-timer)
- Stopwatch: Simple stopwatch with start/pause/reset controls
- Timer: Countdown timer with 9 presets (5-120m) and custom input
- Both follow DMS plugin conventions and use theme tokens

## Test plan

- JSON files are valid and all required fields are present
- `id` and `name` match respective `plugin.json` files
- Screenshot URLs are reachable
- Repo URLs are public and accessible