### PR TITLE
feat: add Timer plugin

### DIFF
--- a/plugins/hthienloc-timer.json
+++ b/plugins/hthienloc-timer.json
@@ -5,7 +5,7 @@
     "category": "utilities",
     "repo": "https://github.com/hthienloc/dms-timer",
     "author": "Loc Huynh",
-    "description": "Feature-rich countdown timer with presets, custom notifications, sound support, and flexible display formats.",
+    "description": "Feature-rich countdown timer.",
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],

--- a/plugins/hthienloc-timer.json
+++ b/plugins/hthienloc-timer.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-timer",
     "author": "Loc Huynh",
     "description": "Feature-rich countdown timer.",
-    "dependencies": [],
+    "dependencies": ["libnotify", "pulseaudio"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-timer/master/screenshot.png"

--- a/plugins/hthienloc-timer.json
+++ b/plugins/hthienloc-timer.json
@@ -1,0 +1,13 @@
+{
+    "id": "timer",
+    "name": "Timer",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-timer",
+    "author": "Loc Huynh",
+    "description": "Feature-rich countdown timer with presets, custom notifications, sound support, and flexible display formats.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-timer/master/screenshot.png"
+}


### PR DESCRIPTION
## Description
Feature-rich countdown timer plugin for Dank Material Shell.

## Features
- **Quick Presets**: Customizable minute buttons (5, 10, 15, 20, 25, 30, 45, 60, 120)
- **Custom Duration**: Input any specific time manually
- **Customizable Notifications**: Toggle desktop notifications, custom title/message
- **Advanced Sound Support**: System critical sound or custom file path
- **Flexible Display**: Multiple bar formats (00:00:00, 1h 5m 10s, 5m 10s)
- **Visual Feedback**: Bar color changes during warnings (≤60s) and timeout
- **Interactive Controls**: Left click for popout, right click to pause/resume

## Installation
```bash
mkdir -p ~/.config/DankMaterialShell/plugins
git clone https://github.com/hthienloc/dms-timer ~/.config/DankMaterialShell/plugins/timer
```

## Repository
https://github.com/hthienloc/dms-timer

## License
GPLv3