### PR TITLE
feat: add Stopwatch plugin

### DIFF
--- a/plugins/hthienloc-stopwatch.json
+++ b/plugins/hthienloc-stopwatch.json
@@ -5,7 +5,7 @@
     "category": "utilities",
     "repo": "https://github.com/hthienloc/dms-stopwatch",
     "author": "Loc Huynh",
-    "description": "High-precision stopwatch with optional millisecond display (Speedrun mode) and customizable bar formats.",
+    "description": "High-precision stopwatch.",
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],

--- a/plugins/hthienloc-stopwatch.json
+++ b/plugins/hthienloc-stopwatch.json
@@ -1,0 +1,13 @@
+{
+    "id": "stopwatch",
+    "name": "Stopwatch",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-stopwatch",
+    "author": "Loc Huynh",
+    "description": "High-precision stopwatch with optional millisecond display (Speedrun mode) and customizable bar formats.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-stopwatch/main/screenshot.png"
+}


### PR DESCRIPTION
## Description
High-precision stopwatch plugin for Dank Material Shell with zero drift.

## Features
- **High Precision**: Optional millisecond display (Speedrun mode) with configurable precision (1-3 digits)
- **Customizable Display**: Toggle time visibility, multiple bar formats (Full/Compact/Minimal)
- **Interactive Controls**: Left click for popout, right click to quick toggle
- **Smart UI**: State-based colors, accessibility hints
- **Theme Integration**: Uses DMS theme tokens, monospace font for aligned digits

## Installation
```bash
mkdir -p ~/.config/DankMaterialShell/plugins
git clone https://github.com/hthienloc/dms-stopwatch ~/.config/DankMaterialShell/plugins/stopwatch
```

## Repository
https://github.com/hthienloc/dms-stopwatch

## License
GPLv3