### PR TITLE
Add ipIndicator plugin

### DIFF
--- a/plugins/hthienloc-ip-indicator.json
+++ b/plugins/hthienloc-ip-indicator.json
@@ -1,0 +1,13 @@
+{
+    "id": "ipIndicator",
+    "name": "IP Indicator",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/hthienloc/dms-ip-indicator",
+    "author": "Loc Huynh",
+    "description": "Shows public IP address, ISP and location. Right-click to toggle privacy mode.",
+    "dependencies": ["curl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ip-indicator/master/screenshot.png"
+}

--- a/plugins/hthienloc-ip-indicator.json
+++ b/plugins/hthienloc-ip-indicator.json
@@ -9,5 +9,5 @@
     "dependencies": ["curl"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ip-indicator/master/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ipIndicator/master/screenshot.png"
 }

--- a/plugins/hthienloc-ipIndicator.json
+++ b/plugins/hthienloc-ipIndicator.json
@@ -3,7 +3,7 @@
     "name": "IP Indicator",
     "capabilities": ["dankbar-widget"],
     "category": "system",
-    "repo": "https://github.com/hthienloc/dms-ip-indicator",
+    "repo": "https://github.com/hthienloc/dms-ipIndicator",
     "author": "Loc Huynh",
     "description": "Shows public IP address, ISP and location. Right-click to toggle privacy mode.",
     "dependencies": ["curl"],


### PR DESCRIPTION
- Added IP Indicator plugin (ipIndicator)
- Shows public IP address, ISP and location
- Right-click to toggle privacy mode
- Settings to show/hide IP, ISP, Location