### PR TITLE
fix: update DankCalendar screenshot URL

### DIFF
--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -1,0 +1,31 @@
+name: Validate Plugin Links
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "plugins/**"
+      - ".github/validate_links.py"
+      - ".github/workflows/validate-links.yml"
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Validate all plugin links
+        run: python3 .github/validate_links.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plugins/alcxyz-dank-calendar.json
+++ b/plugins/alcxyz-dank-calendar.json
@@ -9,5 +9,5 @@
     "dependencies": ["secret-tool", "notify-send"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankCalendar/v0.4.0/docs/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankCalendar/main/docs/screenshot.png"
 }


### PR DESCRIPTION
## Summary
- Update DankCalendar's registry screenshot URL from the non-existent v0.4.0 tag to the live raw image on main.

## Validation
- Confirmed the old v0.4.0 raw URL returns HTTP 404.
- Confirmed the new main raw URL returns HTTP 200 with content-type image/png.