### PR TITLE
refactor: skip validation entirely for plugins not changed in the PR

### DIFF
--- a/.github/validate_links.py
+++ b/.github/validate_links.py
@@ -373,48 +373,38 @@ def main():
 
     changed_files = get_changed_plugin_files()
 
+    if changed_files:
+        plugin_files = [f for f in plugin_files if f.name in changed_files]
+        if not plugin_files:
+            print(f"{GREEN}No plugin files changed in this PR, nothing to validate.{RESET}")
+            sys.exit(0)
+
     print(f"Validating {len(plugin_files)} plugin(s)...\n")
 
-    pr_errors = {}
-    other_errors = {}
+    all_errors = {}
 
     for plugin_file in sorted(plugin_files):
         print(f"Checking {plugin_file.name}...", end=" ")
         errors = validate_plugin(plugin_file)
 
         if errors:
-            if changed_files and plugin_file.name not in changed_files:
-                print(f"{YELLOW}WARNING{RESET}")
-                other_errors[plugin_file.name] = errors
-            else:
-                print(f"{RED}FAILED{RESET}")
-                pr_errors[plugin_file.name] = errors
+            print(f"{RED}FAILED{RESET}")
+            all_errors[plugin_file.name] = errors
         else:
             print(f"{GREEN}OK{RESET}")
 
     # Print summary
     print()
-
-    if other_errors:
-        print(f"{YELLOW}Warnings for plugins not changed in this PR:{RESET}\n")
-        for filename, errors in other_errors.items():
-            print(f"  {YELLOW}⚠ {filename}{RESET}")
-            for error in errors:
-                print(f"    - {error}")
-            print()
-
-    if pr_errors:
-        print(f"{RED}Validation failed for {len(pr_errors)} plugin(s) changed in this PR:{RESET}\n")
-        for filename, errors in pr_errors.items():
+    if all_errors:
+        print(f"{RED}Validation failed for {len(all_errors)} plugin(s):{RESET}\n")
+        for filename, errors in all_errors.items():
             print(f"{RED}✗ {filename}{RESET}")
             for error in errors:
                 print(f"  - {error}")
             print()
         sys.exit(1)
     else:
-        print(f"{GREEN}All plugins changed in this PR validated successfully!{RESET}")
-        if other_errors:
-            print(f"{YELLOW}({len(other_errors)} other plugin(s) have warnings - see above){RESET}")
+        print(f"{GREEN}All plugins validated successfully!{RESET}")
         sys.exit(0)
 
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -41,10 +41,17 @@ jobs:
       - name: Get changed plugin files
         id: changed
         run: |
-          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep '^plugins/' || true)
-          echo "files<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$CHANGED" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          ALL_CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          CI_CHANGED=$(echo "$ALL_CHANGED" | grep '^\.github/' || true)
+          if [ -n "$CI_CHANGED" ]; then
+            echo "CI scripts changed, validating all plugins"
+            echo "files=" >> "$GITHUB_OUTPUT"
+          else
+            CHANGED=$(echo "$ALL_CHANGED" | grep '^plugins/' || true)
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Instead of validating all plugins and downgrading errors to warnings, only validate plugin files that were actually added or changed in the PR
- Saves time by skipping unnecessary network requests (screenshot checks, repo URL checks, plugin.json fetches) for untouched plugins
- When run locally without the `CHANGED_PLUGINS` env var, all plugins are still validated as before

## Test plan
- [ ] Open a PR that changes a valid plugin - should only validate that plugin, not all others
- [ ] Open a PR that changes a plugin with an error - should fail on that plugin
- [ ] Open a PR that only changes non-plugin files - should print "No plugin files changed" and pass
- [ ] Run `python3 .github/validate_links.py` locally - should validate all plugins as before