### PR TITLE
feat: comment validation errors on PR when link checks fail

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  pull-requests: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -56,7 +59,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate plugin links and paths
-        run: python3 .github/validate_links.py
+        id: validate-links
+        run: |
+          python3 .github/validate_links.py 2>&1 | tee /tmp/validate-links-output.txt
+          exit ${PIPESTATUS[0]}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHANGED_PLUGINS: ${{ steps.changed.outputs.files }}
+
+      - name: Comment validation errors on PR
+        if: failure() && steps.validate-links.outcome == 'failure'
+        run: |
+          BODY=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/validate-links-output.txt)
+          gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<EOF
+          ### Plugin validation failed
+
+          \`\`\`
+          $BODY
+          \`\`\`
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- When `validate_links.py` fails, the workflow now posts a comment on the PR with the validation output
- ANSI color codes are stripped so the comment renders cleanly
- Adds `pull-requests: write` permission to the workflow so `gh pr comment` can post
- The check still fails as before - the comment is an additional convenience for contributors

## Test plan
- [ ] Open a PR with an invalid plugin (e.g. broken screenshot URL) - should see a comment with the error details
- [ ] Open a PR with a valid plugin - should pass with no comment posted