### PR TITLE
feat: add Bongo Cat plugin

### DIFF
--- a/plugins/hthienloc-bongo-cat.json
+++ b/plugins/hthienloc-bongo-cat.json
@@ -1,0 +1,13 @@
+{
+    "id": "bongoCat",
+    "name": "Bongo Cat",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-bongo-cat",
+    "author": "Loc Huynh",
+    "description": "A reactive Bongo Cat that taps along with your typing",
+    "dependencies": ["evtest"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-bongo-cat/main/screenshot.png"
+}


### PR DESCRIPTION
Registering the Bongo Cat plugin - a reactive Bongo Cat that taps along with your typing.