### PR TITLE
feat: add Lutris Launcher plugin

### DIFF
--- a/plugins/hthienloc-lutris-launcher.json
+++ b/plugins/hthienloc-lutris-launcher.json
@@ -1,0 +1,13 @@
+{
+    "id": "lutrisLauncher",
+    "name": "Lutris Launcher",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-lutris-launcher",
+    "author": "Loc Huynh",
+    "description": "Quickly launch and manage your Lutris games library directly from the shell bar with keyboard navigation.",
+    "dependencies": ["lutris"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-lutris-launcher/master/screenshot.png"
+}


### PR DESCRIPTION
Registering the Lutris Launcher plugin for hthienloc. A powerful utility to manage and launch Lutris games with advanced keyboard navigation (Tab/Shift+Tab/Enter/Space), search focus, and usage tracking.