### PR TITLE
feat: add OCR Scanner plugin

### DIFF
--- a/plugins/hthienloc-ocr-scanner.json
+++ b/plugins/hthienloc-ocr-scanner.json
@@ -1,0 +1,13 @@
+{
+    "id": "ocrScanner",
+    "name": "OCR Scanner",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-ocr-scanner",
+    "author": "Loc Huynh",
+    "description": "Extract text from images in clipboard or files using Tesseract OCR.",
+    "dependencies": ["tesseract", "wl-clipboard", "kdialog"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ocr-scanner/main/screenshot.png"
+}


### PR DESCRIPTION
Registering the OCR Scanner plugin for hthienloc. This plugin allows users to extract text from images in the clipboard or files using Tesseract OCR, with support for multiple languages and auto-copy functionality.