### PR TITLE
feat: Add kaomoji-picker plugin

### DIFF
--- a/plugins/hthienloc-kaomoji-picker.json
+++ b/plugins/hthienloc-kaomoji-picker.json
@@ -1,0 +1,13 @@
+{
+    "id": "kaomojiPicker",
+    "name": "Kaomoji Picker",
+    "capabilities": ["launcher"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-kaomoji-picker",
+    "author": "Loc Huynh",
+    "description": "Local kaomoji picker for DMS",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-kaomoji-picker/master/screenshot.png"
+}


### PR DESCRIPTION
## Summary
- Add kaomoji picker plugin entry for DMS registry
- Plugin allows local kaomoji search and clipboard copy via DMS launcher