### PR TITLE
Fix validation comment posting on fork PRs

### DIFF
--- a/.github/workflows/comment-validation.yml
+++ b/.github/workflows/comment-validation.yml
@@ -1,0 +1,38 @@
+name: Comment Validation Errors
+
+on:
+  workflow_run:
+    workflows: ["Validate Pull Request"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    steps:
+      - name: Download validation output
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: validation-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR
+        if: steps.download.outcome == 'success'
+        run: |
+          PR_NUMBER=$(cat pr-number.txt)
+          BODY=$(sed 's/\x1b\[[0-9;]*m//g' validate-links-output.txt)
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "### Plugin validation failed
+
+          \`\`\`
+          $BODY
+          \`\`\`"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   validate:
@@ -67,17 +67,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHANGED_PLUGINS: ${{ steps.changed.outputs.files }}
 
-      - name: Comment validation errors on PR
+      - name: Save PR number
         if: failure() && steps.validate-links.outcome == 'failure'
-        run: |
-          BODY=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/validate-links-output.txt)
-          gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<EOF
-          ### Plugin validation failed
+        run: echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
 
-          \`\`\`
-          $BODY
-          \`\`\`
-          EOF
-          )"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload validation output
+        if: failure() && steps.validate-links.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-result
+          path: |
+            /tmp/validate-links-output.txt
+            /tmp/pr-number.txt


### PR DESCRIPTION
## Summary

- Fork PRs receive a read-only GITHUB_TOKEN, causing the validation error comment step to fail with `Resource not accessible by integration`
- Moved PR commenting to a separate `workflow_run`-triggered workflow that runs in the base repo context with write permissions
- Downgraded validate-pr.yml permissions to `contents: read` since it no longer needs write access

## Test plan

- [ ] Open a test PR from a fork with an invalid plugin to verify the comment is posted
- [ ] Verify that valid PRs still pass without triggering the comment workflow