### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/comment-validation.yml
+++ b/.github/workflows/comment-validation.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Download validation output
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: validation-result

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nix-prefetch.yml
+++ b/.github/workflows/nix-prefetch.yml
@@ -16,7 +16,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: cachix/install-nix-action@v31
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Generate plugin data

--- a/.github/workflows/theme-preview.yml
+++ b/.github/workflows/theme-preview.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
 
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: pip install jinja2 requests
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload validation output
         if: failure() && steps.validate-links.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: validation-result
           path: |


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v4/v5 to v6
- Bump `actions/upload-artifact` and `actions/download-artifact` from v4/v5 to v7
- Fixes the Node.js 20 deprecation warning on GitHub Actions runners

## Test plan

- [ ] Verify all workflows pass with the new action versions