### PR TITLE
Add Glance Translate plugin

### DIFF
--- a/plugins/chaoxu1997-glance.json
+++ b/plugins/chaoxu1997-glance.json
@@ -7,6 +7,7 @@
     "path": "plugin",
     "author": "ChaoXu",
     "description": "Popout translation widget for DankMaterialShell bar. Select text, click the translate icon, and get an instant side-by-side translation with copy buttons.",
+    "screenshot": "https://raw.githubusercontent.com/ChaoXu1997/glance/master/docs/screenshot.png",
     "dependencies": ["trans", "wl-clipboard"],
     "compositors": ["any"],
     "distro": ["any"]

--- a/plugins/chaoxu1997-glance.json
+++ b/plugins/chaoxu1997-glance.json
@@ -1,0 +1,13 @@
+{
+    "id": "glance",
+    "name": "Glance Translate",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/ChaoXu1997/glance",
+    "path": "plugin",
+    "author": "ChaoXu",
+    "description": "Popout translation widget for DankMaterialShell bar. Select text, click the translate icon, and get an instant side-by-side translation with copy buttons.",
+    "dependencies": ["trans", "wl-clipboard"],
+    "compositors": ["any"],
+    "distro": ["any"]
+}


### PR DESCRIPTION
Popout translation widget for DankMaterialShell bar. Select text, click the translate icon, and get an instant side-by-side translation with copy buttons.

**Features:**
- Side-by-side source/translation view in popout panel
- Auto-reads primary selection on open
- Debounced auto-translate (500ms)
- One-click copy buttons for source and result
- Configurable target language and engine via settings
- Dependencies: translate-shell, wl-clipboard