### PR TITLE
Add Jira Tickets (dmsJira) plugin

### DIFF
--- a/plugins/klievan-dms-jira.json
+++ b/plugins/klievan-dms-jira.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsJira",
+    "name": "Jira Tickets",
+    "capabilities": ["dankbar-widget"],
+    "category": "productivity",
+    "repo": "https://github.com/Klievan/dms-jira",
+    "author": "Klievan",
+    "description": "Assigned Jira Cloud tickets in the DankBar with quick actions — open, transition status, comment, copy branch name — plus optional new-assignment and @mention notifications.",
+    "dependencies": ["wl-clipboard", "libnotify"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Klievan/dms-jira/8c66f630892c12665643bf4538d0b265adb1a056/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds the Jira Tickets DankBar widget.

Repo: https://github.com/Klievan/dms-jira
Manifest: `plugins/klievan-dms-jira.json` (id `dmsJira`, category `productivity`, capability `dankbar-widget`).

It shows your assigned Jira Cloud tickets on the bar: a pill with the assigned count and the active ticket's key, a popout list (optionally grouped by project), and per-row actions for opening the ticket, pinning it, copying the key or a branch name, changing status via the issue's available transitions, and adding a comment. Optional, off-by-default notifications for tickets newly assigned to you and for comments that @mention you. The API token is read from a file or libsecret, never from the plugin settings, and HTTPS is enforced.

Dependencies: `wl-clipboard` for the copy actions, `libnotify` for notifications.

Ran `.github/generate.py --validate` and `.github/validate_links.py` (scoped to the new file) locally; both pass.