### PR TITLE
Add Extended Network Toggle plugin

### DIFF
--- a/plugins/notherealmarco-extended-network-toggle.json
+++ b/plugins/notherealmarco-extended-network-toggle.json
@@ -1,0 +1,13 @@
+{
+    "id": "extendedNetworkToggle",
+    "name": "Extended Network Toggle",
+    "capabilities": ["control-center"],
+    "category": "system",
+    "repo": "https://github.com/notherealmarco/dms-plugin-extended-network",
+    "author": "Marco Realacci",
+    "description": "Network toggle with Ethernet, WiFi, and Other interfaces (bridges, VLANs, bonds)",
+    "dependencies": ["nmcli"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/notherealmarco/dms-plugin-extended-network/refs/heads/main/docs/screenshot.png"
+}


### PR DESCRIPTION
This adds a network quick toggle that is identical to the built-in wifi/ethernet but it adds an "Other" tab with other network devices like VLANs, Linux bridges and bond networks. 

Repo: https://github.com/notherealmarco/dms-plugin-extended-network
Manifest: plugins/notherealmarco-extended-network-toggle.json (id: `extendedNetworkToggle`, category: `system`, capability: `control-center`).

Dependencies: `NetworkManager` with the `nmcli` command.

Ran .github/generate.py --validate and .github/validate_links.py, they both pass.