### PR TITLE
Add Clash Verge plugin registry entry

### DIFF
--- a/plugins/smithyyang-dms-clash-verge-plugin.json
+++ b/plugins/smithyyang-dms-clash-verge-plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "clashVerge",
+  "name": "Clash Verge",
+  "capabilities": ["dankbar-widget"],
+  "category": "system",
+  "repo": "https://github.com/smithyyang/dms-clash-verge-plugin",
+  "author": "youngshine",
+  "description": "Lightweight Clash Verge overview, switching, and on-demand delay testing popout for DankMaterialShell",
+  "dependencies": ["python3", "python3-venv", "node"],
+  "compositors": ["hyprland"],
+  "distro": ["any"],
+  "requires_dms": ">=1.4.0"
+}

--- a/plugins/smithyyang-dms-clash-verge-plugin.json
+++ b/plugins/smithyyang-dms-clash-verge-plugin.json
@@ -9,5 +9,6 @@
   "dependencies": ["python3", "python3-venv", "node"],
   "compositors": ["hyprland"],
   "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/smithyyang/dms-clash-verge-plugin/main/screenshot.png",
   "requires_dms": ">=1.4.0"
 }


### PR DESCRIPTION
## Summary
- add a registry entry for the `clashVerge` DankMaterialShell plugin
- point the registry to the published repository at `smithyyang/dms-clash-verge-plugin`
- declare the current verified capabilities, dependencies, compositor support, and DMS version requirement