### PR TITLE
feat: add OpenTrackerBar plugin

### DIFF
--- a/plugins/wsmajt-opentrackerbar.json
+++ b/plugins/wsmajt-opentrackerbar.json
@@ -9,5 +9,5 @@
     "dependencies": ["opentracker-cli"],
     "compositors": ["niri", "hyprland", "sway", "river"],
     "distro": ["any"],
-    "screenshot": ""
+    "screenshot": "https://private-user-images.githubusercontent.com/70204246/595015648-fad23f59-286b-4c00-a01d-bae6bed4f1ca.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzkyODcxOTIsIm5iZiI6MTc3OTI4Njg5MiwicGF0aCI6Ii83MDIwNDI0Ni81OTUwMTU2NDgtZmFkMjNmNTktMjg2Yi00YzAwLWEwMWQtYmFlNmJlZDRmMWNhLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MjAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTIwVDE0MjEzMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFmMWVlOTIzZDU5NTg1YWUwZTVmMzQwOWFiOGYzNzFiNmFiMzc0MzMzYjljZjFlZThlYjBlZGMzNDUxOTAxMjcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.Y3vs_H1mYV1fCiIQ5MfaXZ4szDDIrsqXVN_LoqoeHY4"
 }

--- a/plugins/wsmajt-opentrackerbar.json
+++ b/plugins/wsmajt-opentrackerbar.json
@@ -1,0 +1,13 @@
+{
+    "id": "openTrackerBar",
+    "name": "OpenTrackerBar",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/wsmajt/OpenTrackerBar",
+    "author": "smajt",
+    "description": "Track OpenCode.ai usage limits (session/weekly/monthly) via opentracker CLI",
+    "dependencies": ["opentracker-cli"],
+    "compositors": ["niri", "hyprland", "sway", "river"],
+    "distro": ["any"],
+    "screenshot": ""
+}

--- a/plugins/wsmajt-opentrackerbar.json
+++ b/plugins/wsmajt-opentrackerbar.json
@@ -1,13 +1,13 @@
 {
-    "id": "openTrackerBar",
-    "name": "OpenTrackerBar",
-    "capabilities": ["dankbar-widget"],
-    "category": "monitoring",
-    "repo": "https://github.com/wsmajt/OpenTrackerBar",
-    "author": "smajt",
-    "description": "Track OpenCode.ai usage limits (session/weekly/monthly) via opentracker CLI",
-    "dependencies": ["opentracker-cli"],
-    "compositors": ["niri", "hyprland", "sway", "river"],
-    "distro": ["any"],
-    "screenshot": "https://private-user-images.githubusercontent.com/70204246/595015648-fad23f59-286b-4c00-a01d-bae6bed4f1ca.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzkyODcxOTIsIm5iZiI6MTc3OTI4Njg5MiwicGF0aCI6Ii83MDIwNDI0Ni81OTUwMTU2NDgtZmFkMjNmNTktMjg2Yi00YzAwLWEwMWQtYmFlNmJlZDRmMWNhLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MjAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTIwVDE0MjEzMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFmMWVlOTIzZDU5NTg1YWUwZTVmMzQwOWFiOGYzNzFiNmFiMzc0MzMzYjljZjFlZThlYjBlZGMzNDUxOTAxMjcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.Y3vs_H1mYV1fCiIQ5MfaXZ4szDDIrsqXVN_LoqoeHY4"
+  "id": "openTrackerBar",
+  "name": "OpenTrackerBar",
+  "capabilities": ["dankbar-widget"],
+  "category": "monitoring",
+  "repo": "https://github.com/wsmajt/OpenTrackerBar",
+  "author": "smajt",
+  "description": "Track AI usage limits via opentracker CLI",
+  "dependencies": ["opentracker-cli"],
+  "compositors": ["niri", "hyprland", "sway", "river"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/wsmajt/OpenTrackerBar/refs/heads/main/Screenshot.png"
 }


### PR DESCRIPTION
## OpenTrackerBar
Plugin for DankMaterialShell that tracks OpenCode.ai usage limits via the [opentracker](https://github.com/wsmajt/opentracker) CLI.
### Features
- Displays rolling (session), weekly, and monthly usage percentages
- Color-coded progress bars (green/yellow/red based on usage)
- Interactive setup on first run
- Clean JSON output piped from CLI to QML
### Requirements
- [opentracker-cli](https://aur.archlinux.org/packages/opentracker-cli) (AUR)
### Setup
1. `yay -S opentracker-cli`
2. `opentracker login opencode`
3. Export Netscape cookies to `~/.config/opentracker/opencode-cookies.txt`
4. `opentracker fetch opencode-go` (first run prompts for workspace ID)
5. Enable `OpenTrackerBar` in DankMaterialShell settings
### Links
- Plugin repo: https://github.com/wsmajt/OpenTrackerBar
- CLI repo: https://github.com/wsmajt/opentracker
### Validation
- [x] JSON schema validated (`python3 .github/generate.py --validate`)
- [x] `id` and `name` match plugin repository's `plugin.json`