### PR TITLE
Add arqueon/weekly-calendar plugin

### DIFF
--- a/plugins/arqueon-screenrecorder.json
+++ b/plugins/arqueon-screenrecorder.json
@@ -7,7 +7,7 @@
     "category": "utilities",
     "repo": "https://github.com/arqueon/dms-screen-recorder",
     "author": "arqueon",
-    "description": "Start, stop, and configure screen captures with gpu-screen-recorder (Wayland: niri, Hyprland, etc.)",
+    "description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor. Supports IPC keybinds.",
     "dependencies": [
         "gpu-screen-recorder"
     ],

--- a/plugins/arqueon-weekly-calendar.json
+++ b/plugins/arqueon-weekly-calendar.json
@@ -1,0 +1,23 @@
+{
+    "id": "weeklyCalendar",
+    "name": "Weekly Calendar",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/arqueon/dms-calendar",
+    "author": "arqueon (ported from dodaars)",
+    "description": "A Material 3 weekly calendar with five views (Week, 4 Days, Day, Agenda, Month), Evolution Data Server integration for Google/Nextcloud/CalDAV calendars, event creation from the widget, tooltips, overlap management, and Evolution deep-link on click.",
+    "dependencies": [
+        "evolution-data-server",
+        "python-dateutil",
+        "libical"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://github.com/user-attachments/assets/cb3352b0-addb-43a4-a89c-b3ce011a29f0"
+}

--- a/plugins/arqueon-weekly-calendar.json
+++ b/plugins/arqueon-weekly-calendar.json
@@ -19,5 +19,5 @@
     "distro": [
         "any"
     ],
-    "screenshot": "https://github.com/user-attachments/assets/cb3352b0-addb-43a4-a89c-b3ce011a29f0"
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-calendar/master/assets/screenshot.png"
 }


### PR DESCRIPTION
## Plugin submission: Weekly Calendar

**Plugin ID:** `weeklyCalendar`
**Repository:** https://github.com/arqueon/dms-calendar

### Description

A Material 3 weekly calendar widget with five views (Week, 4 Days, Day, Agenda, Month), native Evolution Data Server integration for Google/Nextcloud/CalDAV calendars, inline event creation, smart overlap management, and Evolution deep-link on event click.

### Checklist

- [x] `id` and `name` match the plugin's internal `plugin.json`
- [x] All required fields present (`id`, `name`, `capabilities`, `category`, `repo`, `author`, `description`, `dependencies`, `compositors`, `distro`)
- [x] `python3 .github/generate.py --validate` passes locally
- [x] Screenshot URL included
- [x] Plugin has a complete README with installation instructions