### PR TITLE
add hostname-widget plugin

### DIFF
--- a/plugins/irunatbullets-hostname-widget.json
+++ b/plugins/irunatbullets-hostname-widget.json
@@ -1,0 +1,14 @@
+{
+  "id": "hostnameWidget",
+  "name": "Hostname Widget",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/irunatbullets/hostname-widget",
+  "author": "irunatbullets",
+  "description": "A widget for displaying your hostname",
+  "dependencies": ["dms"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/irunatbullets/hostname-widget/main/assets/screenshot.png"
+}
+


### PR DESCRIPTION
I've created a very basic hostname widget. My specific usecase is that I have dotfiles shared between multiple computers which are connected to one monitor. Sometimes its difficult to identify which machine I'm using because the desktops are identical.