### PR TITLE
Add Resource Monitor plugin

### DIFF
--- a/plugins/smithyyang-resource-monitor.json
+++ b/plugins/smithyyang-resource-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "resourceMonitor",
+    "name": "Resource Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/smithyyang/dms-resource-monitor",
+    "author": "youngshine",
+    "description": "Real-time CPU, memory and swap usage with circular progress indicators",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/smithyyang/dms-resource-monitor/main/assets/screenshot.png"
+}


### PR DESCRIPTION
## Summary

Adds the **Resource Monitor** plugin entry to the registry.

- **ID:** `resourceMonitor`
- **Name:** Resource Monitor
- **Author:** youngshine
- **Repo:** https://github.com/smithyyang/dms-resource-monitor
- **Capabilities:** `dankbar-widget`
- **Category:** monitoring

### Screenshot

![Resource Monitor](https://raw.githubusercontent.com/smithyyang/dms-resource-monitor/main/assets/screenshot.png)