### PR TITLE
Add DeepSeek Usage (deepseekWidget) plugin

### DIFF
--- a/plugins/gylove1994-deepseek-dms-widget.json
+++ b/plugins/gylove1994-deepseek-dms-widget.json
@@ -1,0 +1,13 @@
+{
+  "id": "deepseekWidget",
+  "name": "DeepSeek Usage",
+  "capabilities": ["dankbar-widget"],
+  "category": "monitoring",
+  "repo": "https://github.com/gylove1994/deepseek-dms-widget",
+  "author": "gylove1994",
+  "description": "DeepSeek Platform API balance, monthly token usage and cost in the DankBar; Playwright-based cookie login.",
+  "dependencies": ["python3"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/gylove1994/deepseek-dms-widget/master/screenshots/bar-pill.png"
+}


### PR DESCRIPTION
## Summary

- Registers [gylove1994/deepseek-dms-widget](https://github.com/gylove1994/deepseek-dms-widget): DeepSeek Platform API balance, token usage, and cost in the DankBar (`id`/`name` match upstream `plugin.json`).

## Test plan

- [x] `python3 .github/generate.py --validate`
- [x] `CHANGED_PLUGINS=plugins/gylove1994-deepseek-dms-widget.json python3 .github/validate_links.py` (single-plugin scope; upstream CI validates the full set)


Made with [Cursor](https://cursor.com)