### PR TITLE
Deepseek API Account Balance Widget

### DIFF
--- a/plugins/juliuswms-deepseekbalance.json
+++ b/plugins/juliuswms-deepseekbalance.json
@@ -1,0 +1,13 @@
+{
+    "id": "deepseekBalance",
+    "name": "DeepSeek Balance",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/juliuswms/dms-deepseekbalance",
+    "author": "eugene :)",
+    "description": "Display your DeepSeek API account balance in the taskbar",
+    "dependencies": ["jq"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/juliuswms/dms-deepseekbalance/blob/main/screenshot.png"
+}

--- a/plugins/juliuswms-deepseekbalance.json
+++ b/plugins/juliuswms-deepseekbalance.json
@@ -9,5 +9,5 @@
     "dependencies": ["jq"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://github.com/juliuswms/dms-deepseekbalance/blob/main/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/juliuswms/dms-deepseekbalance/main/screenshot.png"
 }


### PR DESCRIPTION
Hey, I switched from Claude to Deepseek and was missing [Nicolas Bellamy](https://github.com/titeya) Claude Code Usage Widget to Display my Balance. Thats why I made one for the Deepseek API. It's not as feature rich as Nicolas version yet but it works and does what it should.