### PR TITLE
feat: register hthienloc-hydrate and hthienloc-niriDS plugins

### DIFF
--- a/plugins/hthienloc-hydrate.json
+++ b/plugins/hthienloc-hydrate.json
@@ -1,0 +1,13 @@
+{
+    "id": "hydrate",
+    "name": "Hydrate",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-hydrate",
+    "author": "Loc Huynh",
+    "description": "Drink water reminder and tracker.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-hydrate/master/screenshot.png"
+}

--- a/plugins/hthienloc-niriDS.json
+++ b/plugins/hthienloc-niriDS.json
@@ -1,0 +1,13 @@
+{
+    "id": "niriDS",
+    "name": "Niri Display Settings",
+    "capabilities": ["daemon"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-niri-display-settings",
+    "author": "Loc Huynh",
+    "description": "Quickly toggle and configure display outputs in the Niri Wayland compositor with automatic laptop fallback protection.",
+    "dependencies": ["niri"],
+    "compositors": ["niri"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-niri-display-settings/master/screenshot.png"
+}


### PR DESCRIPTION
Registers two new plugins for Dank Material Shell:

1. **Hydrate** (`hthienloc-hydrate`): A sleek drink water reminder and tracker widget plugin.
2. **Niri Display Settings** (`hthienloc-niriDS`): A comprehensive display toggle and output settings service/daemon designed specifically for the Niri Wayland compositor, featuring dynamic fallback protection to prevent black screens.