### PR TITLE
Add Mouse Battery & DPI plugin

### DIFF
--- a/plugins/ripolin99-mouse-battery.json
+++ b/plugins/ripolin99-mouse-battery.json
@@ -1,0 +1,13 @@
+{
+    "id": "mouseBattery",
+    "name": "Mouse Battery & DPI",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/Ripolin99/dms-mouse-battery",
+    "author": "Ripolin99",
+    "description": "Wireless mouse battery in the bar with a DPI preset grid (Solaar / ratbagctl).",
+    "dependencies": ["upower", "solaar", "libratbag"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Ripolin99/dms-mouse-battery/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds an entry for [dms-mouse-battery](https://github.com/Ripolin99/dms-mouse-battery), a DankMaterialShell bar plugin that:

- Shows the wireless mouse battery percentage via `upower` (works with Logitech HID++, Bluetooth, and generic HID power-supply devices).
- Exposes a 4×3 grid of DPI presets in its popout. A click on a preset applies the new DPI immediately.
- Supports two DPI backends with auto-detection: **Solaar** (Logitech HID++) and **ratbagctl** (libratbag).
- Ships a small Python wrapper (`solaar-dpi.py`) that works around a Solaar CLI bug on keyed `dpi_extended` settings and auto-disables onboard profiles when they block external DPI changes.

Repository: https://github.com/Ripolin99/dms-mouse-battery
License: GPL-3.0

Local validation:
- `python3 .github/generate.py --validate` → Validation successful
- `CHANGED_PLUGINS=plugins/ripolin99-mouse-battery.json python3 .github/validate_links.py` → All plugins validated successfully