### PR TITLE
Add Nix Package Runner plugin

### DIFF
--- a/plugins/iahccc-nixpackagerunner.json
+++ b/plugins/iahccc-nixpackagerunner.json
@@ -1,0 +1,13 @@
+{
+  "id": "nixPackageRunner",
+  "name": "Nix Package Runner",
+  "capabilities": ["launcher"],
+  "category": "utilities",
+  "repo": "https://github.com/iahccc/NixPackageRunner",
+  "author": "iahc",
+  "description": "Search nixpkgs with nix search, launch directly with nix run, and copy nix shell commands from the context menu",
+  "dependencies": ["nix", "jq", "wl-clipboard"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://github.com/iahccc/NixPackageRunner/raw/main/screenshot.png"
+}


### PR DESCRIPTION
A launcher plugin for searching and running nixpkgs packages via DankMaterialShell.

Features:
- Search nixpkgs with nix search
- Launch with nix run or in terminal
- Copy nix shell commands to clipboard
- Recent packages history
- Configurable trigger and settings

Repo: https://github.com/iahccc/NixPackageRunner