### PR TITLE
Add GitHub inbox plugin

### DIFF
--- a/plugins/tms-namespace-github-inbox.json
+++ b/plugins/tms-namespace-github-inbox.json
@@ -1,5 +1,5 @@
 {
-    "id": "github-inbox",
+    "id": "githubInbox",
     "name": "GitHub Inbox",
     "capabilities": ["dankbar-widget"],
     "category": "productivity",

--- a/plugins/tms-namespace-github-inbox.json
+++ b/plugins/tms-namespace-github-inbox.json
@@ -14,5 +14,7 @@
     "permissions": ["settings_read", "settings_write", "process", "network"],
     "requires_dms": ">=1.2.0",
     "dependencies": ["curl", "secret-tool", "jq"],
+    "compositors": [],
+    "distro": [],
     "screenshot": "https://github.com/TMS-Namespace/DMS-GitHub-Inbox-Plugin/raw/main/Images/plugin_group_by_date.png"
 }

--- a/plugins/tms-namespace-github-inbox.json
+++ b/plugins/tms-namespace-github-inbox.json
@@ -13,8 +13,6 @@
     "settings": "./QML/Views/Settings.qml",
     "permissions": ["settings_read", "settings_write", "process", "network"],
     "requires_dms": ">=1.2.0",
-    "distro": ["fedora"],
-    "compositors": ["niri"],
     "dependencies": ["curl", "secret-tool", "jq"],
     "screenshot": "https://github.com/TMS-Namespace/DMS-GitHub-Inbox-Plugin/raw/main/Images/plugin_group_by_date.png"
 }

--- a/plugins/tms-namespace-github-inbox.json
+++ b/plugins/tms-namespace-github-inbox.json
@@ -14,7 +14,7 @@
     "permissions": ["settings_read", "settings_write", "process", "network"],
     "requires_dms": ">=1.2.0",
     "dependencies": ["curl", "secret-tool", "jq"],
-    "compositors": [],
-    "distro": [],
+    "compositors": ["any"],
+    "distro": ["any"],
     "screenshot": "https://github.com/TMS-Namespace/DMS-GitHub-Inbox-Plugin/raw/main/Images/plugin_group_by_date.png"
 }

--- a/plugins/tms-namespace-github-inbox.json
+++ b/plugins/tms-namespace-github-inbox.json
@@ -1,0 +1,20 @@
+{
+    "id": "github-inbox",
+    "name": "GitHub Inbox",
+    "capabilities": ["dankbar-widget"],
+    "category": "productivity",
+    "repo": "https://github.com/TMS-Namespace/DMS-GitHub-Inbox-Plugin",
+    "description": "Shows your GitHub notifications (aka inbox) in a popup and lets you mark them as read or done.",
+    "version": "1.0.0",
+    "author": "TMS-Namespace",
+    "icon": "code",
+    "type": "widget",
+    "component": "./QML/Widget.qml",
+    "settings": "./QML/Views/Settings.qml",
+    "permissions": ["settings_read", "settings_write", "process", "network"],
+    "requires_dms": ">=1.2.0",
+    "distro": ["fedora"],
+    "compositors": ["niri"],
+    "dependencies": ["curl", "secret-tool", "jq"],
+    "screenshot": "https://github.com/TMS-Namespace/DMS-GitHub-Inbox-Plugin/raw/main/Images/plugin_group_by_date.png"
+}


### PR DESCRIPTION
New plugin: Shows your GitHub notifications (aka inbox) in a popup and lets you mark them as read or done