### PR TITLE
add: ZeroTier Manager plugin

### DIFF
--- a/plugins/nfrastack-zerotierManager.json
+++ b/plugins/nfrastack-zerotierManager.json
@@ -1,0 +1,13 @@
+{
+    "id": "zerotierManager",
+    "name": "ZeroTier Manager",
+    "capabilities": ["dankbar-widget"],
+    "category": "networking",
+    "repo": "https://github.com/nfrastack/dms-zerotierManager",
+    "author": "nfrastack",
+    "description": "Show ZeroTier network status in the bar and join/leave/route networks from a popout.",
+    "dependencies": ["zerotier-cli"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/nfrastack/dms-zerotierManager/refs/heads/main/img/overview.jpg"
+}


### PR DESCRIPTION
This adds the nfrastack/dms-zerotierManager plugin allowing for a user to control their connections to zeroTier networks from the bar, and toggle DNS or exit node overrides.
