### PR TITLE
Add TLP Power Profile plugin

### DIFF
--- a/plugins/peturh-tlp-power-profile.json
+++ b/plugins/peturh-tlp-power-profile.json
@@ -1,0 +1,13 @@
+{
+    "id": "tlpPowerProfile",
+    "name": "TLP Power Profile",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/peturh/tlp-power-profile",
+    "author": "petur",
+    "description": "Battery widget backed by TLP, exposing editable power profiles and charge thresholds.",
+    "dependencies": ["tlp"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/peturh/tlp-power-profile/main/assets/screenshot1.jpg"
+}


### PR DESCRIPTION
Adds an entry for [tlp-power-profile](https://github.com/peturh/tlp-power-profile) — a DankBar widget backed by TLP that exposes editable power profiles and battery charge thresholds (features `power-profiles-daemon` does not provide).

- Category: `system`
- Compositors: `any`
- Distros: `any`
- Dependencies: `tlp`

Validated locally with `python3 .github/generate.py --validate` and `python3 .github/validate_links.py`.