### PR TITLE
Add System Monitor Plus plugin

### DIFF
--- a/nix/plugins-prefetch.json
+++ b/nix/plugins-prefetch.json
@@ -113,12 +113,12 @@
     "url": "https://github.com/devnullvoid/dms-ai-assistant"
   },
   "aiOverviewControl": {
-    "date": "2026-05-20T19:39:32-03:00",
+    "date": "2026-05-25T01:59:01-03:00",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-6UXxZq0nw34ozdTfyyPGKRZNcpzg2Lkysirnjsfjf/U=",
+    "hash": "sha256-0MrQsbgL4Wkm/KTv0QKFgAwuCyvirHEOJp1xenFV+XQ=",
     "leaveDotGit": false,
     "meta": {
       "author": "Bernardo Gomes",
@@ -144,10 +144,10 @@
       "screenshot": "https://raw.githubusercontent.com/bernardopg/AiOverviewControl/main/screenshot.png",
       "version": "1.2.2"
     },
-    "path": "/nix/store/fc84dyawii33qbfvvyxqmrimv0nlw0a5-AiOverviewControl",
-    "rev": "c71672b31ad471f11a40b3a668de7d86c9423a6c",
+    "path": "/nix/store/1xkd8j992yrpvmrbxrsi6d3jxlwbsi7y-AiOverviewControl",
+    "rev": "585e09bcdd3c51376b79a53b2dfcf1935997a7a6",
     "rootDir": "",
-    "sha256": "1xbzwg3qxrran8rbkn70kir4s5i9qqiwppylrll7xhr7mmkg2ig9",
+    "sha256": "0x7ramqplwcx4q773b725c5jw340hl1d3vx4zhk6kq8bp2qx1jnh",
     "url": "https://github.com/bernardopg/AiOverviewControl"
   },
   "airQuality": {
@@ -1001,12 +1001,12 @@
     "url": "https://github.com/titeya/dms-claudecode"
   },
   "clipboardPlus": {
-    "date": "2026-05-15T02:07:10+07:00",
+    "date": "2026-05-26T00:05:59+07:00",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-HQJLLdymHCrBhsUcLXMb02pB/JENNF4Ls7F7EOHS4Jo=",
+    "hash": "sha256-0HUZQmXVQjMRb+E3q/q3cZBBY4xNQ1HEiz4Fipu+0yA=",
     "leaveDotGit": false,
     "meta": {
       "author": "Dadangdut33",
@@ -1032,10 +1032,10 @@
       "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/ClipboardPlus/preview/preview-blur.png",
       "version": "1.1.1"
     },
-    "path": "/nix/store/y52qns7ippk0bvg9asigjv5baajc745s-dms-plugins",
-    "rev": "d71b83f0240820f4132a42aebf974a4f86ed3ba9",
+    "path": "/nix/store/i8hj75fw1y31vfwf40fb0cqlgc1cmh9p-dms-plugins",
+    "rev": "348d886a3176e9f06c728aa03e0273d5d1e4bb1c",
     "rootDir": "",
-    "sha256": "16p0sbhi0yxinc5mwd0dj7y42snk3drjs765hv0jl756vhnln0hx",
+    "sha256": "086kpsdql19yig252hsdiiil343inzxandz1dw8k6hnmcm11jxfh",
     "url": "https://github.com/Dadangdut33/dms-plugins"
   },
   "codeIsland": {
@@ -4464,12 +4464,12 @@
     "url": "https://github.com/TMS-Namespace/DMS-Markets-Plugin"
   },
   "mediaControlPlus": {
-    "date": "2026-05-15T02:07:10+07:00",
+    "date": "2026-05-26T00:05:59+07:00",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-HQJLLdymHCrBhsUcLXMb02pB/JENNF4Ls7F7EOHS4Jo=",
+    "hash": "sha256-0HUZQmXVQjMRb+E3q/q3cZBBY4xNQ1HEiz4Fipu+0yA=",
     "leaveDotGit": false,
     "meta": {
       "author": "Dadangdut33",
@@ -4492,10 +4492,10 @@
       "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/MediaControlPlus/preview/vertical.png",
       "version": "1.0.4"
     },
-    "path": "/nix/store/y52qns7ippk0bvg9asigjv5baajc745s-dms-plugins",
-    "rev": "d71b83f0240820f4132a42aebf974a4f86ed3ba9",
+    "path": "/nix/store/i8hj75fw1y31vfwf40fb0cqlgc1cmh9p-dms-plugins",
+    "rev": "348d886a3176e9f06c728aa03e0273d5d1e4bb1c",
     "rootDir": "",
-    "sha256": "16p0sbhi0yxinc5mwd0dj7y42snk3drjs765hv0jl756vhnln0hx",
+    "sha256": "086kpsdql19yig252hsdiiil343inzxandz1dw8k6hnmcm11jxfh",
     "url": "https://github.com/Dadangdut33/dms-plugins"
   },
   "mediaControlsPlus": {
@@ -4713,12 +4713,12 @@
     "url": "https://github.com/AC17dollars/dms-nepali-calendar"
   },
   "netbirdStatus": {
-    "date": "2026-05-15T02:07:10+07:00",
+    "date": "2026-05-26T00:05:59+07:00",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-HQJLLdymHCrBhsUcLXMb02pB/JENNF4Ls7F7EOHS4Jo=",
+    "hash": "sha256-0HUZQmXVQjMRb+E3q/q3cZBBY4xNQ1HEiz4Fipu+0yA=",
     "leaveDotGit": false,
     "meta": {
       "author": "Dadangdut33",
@@ -4743,10 +4743,10 @@
       "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/NetbirdStatus/preview/widget.png",
       "version": "1.0.0"
     },
-    "path": "/nix/store/y52qns7ippk0bvg9asigjv5baajc745s-dms-plugins",
-    "rev": "d71b83f0240820f4132a42aebf974a4f86ed3ba9",
+    "path": "/nix/store/i8hj75fw1y31vfwf40fb0cqlgc1cmh9p-dms-plugins",
+    "rev": "348d886a3176e9f06c728aa03e0273d5d1e4bb1c",
     "rootDir": "",
-    "sha256": "16p0sbhi0yxinc5mwd0dj7y42snk3drjs765hv0jl756vhnln0hx",
+    "sha256": "086kpsdql19yig252hsdiiil343inzxandz1dw8k6hnmcm11jxfh",
     "url": "https://github.com/Dadangdut33/dms-plugins"
   },
   "nextBootSelector": {
@@ -5816,12 +5816,12 @@
     "url": "https://github.com/lpv11/dms-hypr-show-desktop"
   },
   "simpleAudioControl": {
-    "date": "2026-05-15T02:07:10+07:00",
+    "date": "2026-05-26T00:05:59+07:00",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-HQJLLdymHCrBhsUcLXMb02pB/JENNF4Ls7F7EOHS4Jo=",
+    "hash": "sha256-0HUZQmXVQjMRb+E3q/q3cZBBY4xNQ1HEiz4Fipu+0yA=",
     "leaveDotGit": false,
     "meta": {
       "author": "Dadangdut33",
@@ -5844,10 +5844,10 @@
       "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/SimpleAudioControl/preview/tab-1.png",
       "version": "1.0.4"
     },
-    "path": "/nix/store/y52qns7ippk0bvg9asigjv5baajc745s-dms-plugins",
-    "rev": "d71b83f0240820f4132a42aebf974a4f86ed3ba9",
+    "path": "/nix/store/i8hj75fw1y31vfwf40fb0cqlgc1cmh9p-dms-plugins",
+    "rev": "348d886a3176e9f06c728aa03e0273d5d1e4bb1c",
     "rootDir": "",
-    "sha256": "16p0sbhi0yxinc5mwd0dj7y42snk3drjs765hv0jl756vhnln0hx",
+    "sha256": "086kpsdql19yig252hsdiiil343inzxandz1dw8k6hnmcm11jxfh",
     "url": "https://github.com/Dadangdut33/dms-plugins"
   },
   "sshConnections": {
@@ -6034,12 +6034,12 @@
     "url": "https://github.com/leemeng0x61/stockManager"
   },
   "stopwatch": {
-    "date": "2026-05-16T16:41:23+07:00",
+    "date": "2026-05-25T22:40:30+07:00",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-tkNEOVZq7cwWbIIs+hd+BTng5qK0sIGJJG8WoFqM/C8=",
+    "hash": "sha256-1hygDpuaPjnklrxkMzwznyJ0o1l4qEvbJp3zi+dIV1g=",
     "leaveDotGit": false,
     "meta": {
       "author": "Loc Huynh",
@@ -6061,11 +6061,46 @@
       "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-stopwatch/main/screenshot.png",
       "version": "1.2.1"
     },
-    "path": "/nix/store/gndvvvqkl5yrajh0mhdcda8a1qrv2h96-dms-stopwatch",
-    "rev": "3dc01c6a5df2014c675c3f535a55f06ecc057a04",
+    "path": "/nix/store/jxp8riwdib2xby1rkbzymrabvl4vkkbd-dms-stopwatch",
+    "rev": "747a98c25301996e188d34c617ee38f612312f73",
     "rootDir": "",
-    "sha256": "0bzwiida05kg4j4q3c5llbkf0f85gqbzlb42dhbcrvbaaqwl8hxn",
+    "sha256": "0n2p93kqpwwx4vdlpa3qb6ip88lz6cy36r5wjvj3jglskc7a076n",
     "url": "https://github.com/hthienloc/dms-stopwatch"
+  },
+  "systemMonitorPlus": {
+    "date": "2026-05-26T00:05:59+07:00",
+    "deepClone": false,
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "fetchTags": false,
+    "hash": "sha256-0HUZQmXVQjMRb+E3q/q3cZBBY4xNQ1HEiz4Fipu+0yA=",
+    "leaveDotGit": false,
+    "meta": {
+      "author": "Dadangdut33",
+      "capabilities": [
+        "dankbar-widget"
+      ],
+      "category": "utilities",
+      "compositors": [
+        "any"
+      ],
+      "dependencies": [],
+      "description": "Unified DMS system monitor with capabilities to customize resources order, resource shown, colors, and new styles.",
+      "distro": [
+        "any"
+      ],
+      "id": "systemMonitorPlus",
+      "name": "System Monitor Plus",
+      "path": "SystemMonitorPlus",
+      "repo": "https://github.com/Dadangdut33/dms-plugins",
+      "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/SystemMonitorPlus/preview/preview.png",
+      "version": "1.0.0"
+    },
+    "path": "/nix/store/i8hj75fw1y31vfwf40fb0cqlgc1cmh9p-dms-plugins",
+    "rev": "348d886a3176e9f06c728aa03e0273d5d1e4bb1c",
+    "rootDir": "",
+    "sha256": "086kpsdql19yig252hsdiiil343inzxandz1dw8k6hnmcm11jxfh",
+    "url": "https://github.com/Dadangdut33/dms-plugins"
   },
   "tailscale": {
     "date": "2025-12-28T23:10:04-05:00",
@@ -6104,12 +6139,12 @@
     "url": "https://github.com/cglavin50/dms-tailscale"
   },
   "tasks": {
-    "date": "2026-04-23T20:21:04+05:30",
+    "date": "2026-05-25T17:59:02+05:30",
     "deepClone": false,
     "fetchLFS": false,
     "fetchSubmodules": false,
     "fetchTags": false,
-    "hash": "sha256-eg9RVNww41y0j5TazqQH60cBlTKP2wjaBNGXZGXsm6M=",
+    "hash": "sha256-Mpt9jU/eVI4nkHnaXwFDrueW+i9MG4YflNt3B6yhZQk=",
     "leaveDotGit": false,
     "meta": {
       "author": "Yasiru Dharmathilaka",
@@ -6134,10 +6169,10 @@
       "screenshot": "https://raw.githubusercontent.com/AyoItsYas/dms-tasks/refs/heads/main/screenshot.png",
       "version": "1.1.2"
     },
-    "path": "/nix/store/qs1rxip0hmdrvanlc2hfr3pj6rdj3yfh-dms-tasks",
-    "rev": "cda181e17123b99e69a3e710b4487bb5f43f30ff",
+    "path": "/nix/store/aa2z2201pcgqjl1hlfifz57cdwn0a4ai-dms-tasks",
+    "rev": "d58822c5e307e92e5ca91dc4d609aff463ea2afb",
     "rootDir": "",
-    "sha256": "18wvxijn95yi0kd0inwg6aah2izb0yjcxnlliys5rqrhvia523vs",
+    "sha256": "02b5l6n0fxyvjhgqc6sc5zx9drxf8c0mznkrj0kqwm6y9y6pv6rj",
     "url": "https://github.com/AyoItsYas/dms-tasks"
   },
   "taskwarrior": {

--- a/plugins/dadangdut33-systemmonitorplus.json
+++ b/plugins/dadangdut33-systemmonitorplus.json
@@ -1,0 +1,14 @@
+{
+    "id": "systemMonitorPlus",
+    "name": "System Monitor Plus",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Dadangdut33/dms-plugins",
+    "path": "SystemMonitorPlus",
+    "author": "Dadangdut33",
+    "description": "Unified DMS system monitor with capabilities to customize resources order, resource shown, colors, and new styles.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Dadangdut33/dms-plugins/master/SystemMonitorPlus/preview/preview.png"
+}


### PR DESCRIPTION
A customized version of the resource monitoring plugin from DMS that aim to unifies the resource monitoring and add more customizable settings.

## Features

- Switch between `CPU usage`, `CPU temperature`, `RAM usage`, and `GPU temperature`
- Three looks:
  - `Default`: icon + text
  - `Gauge`: icon with a circular speedometer-style ring
  - `Bar`: icon with a usage bar
- Fixed color mode or automatic `normal / warning / danger` colors
- Opens the stock DMS process-list popout when clicked
- Reads system data from `DgopService`

## Preview

![Preview](https://github.com/Dadangdut33/dms-plugins/blob/master/SystemMonitorPlus/preview/preview.png?raw=true)