### PR TITLE
feat: add new network indicator plugin to registry

### DIFF
--- a/plugins/gemb0-0-network-indicator.json
+++ b/plugins/gemb0-0-network-indicator.json
@@ -1,0 +1,19 @@
+{
+    "id": "networkIndicator",
+    "name": "Network Indicator",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "monitoring",
+    "repo": "https://github.com/gemb0-0/Network-Indicator.git",
+    "author": "gemb0_0",
+    "description": "Real-time network speed monitor for DankBar showing upload and download speeds",
+    "dependencies": [],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://github.com/gemb0-0/Network-Indicator/blob/master/screenshot.png"
+}


### PR DESCRIPTION
Summary
Adds the Network Indicator plugin to the DMS plugin registry.

What it does
Network Indicator is a real-time network speed monitor DankBar widget that displays live upload and download speeds. It reads from /proc/net/dev and tracks daily usage history with persistent storage via the DMS Plugin State API.

Changes
Added plugins/gemb0-0-network-indicator.json — the registry entry for the plugin
Category: monitoring
Capability: dankbar-widget
Compositor/Distro: any
Dependencies: none
Repo: https://github.com/gemb0-0/Network-Indicator.git
