### PR TITLE
Add DMS Framework Battery plugin

### DIFF
--- a/plugins/nfoert-dmsframeworkbattery.json
+++ b/plugins/nfoert-dmsframeworkbattery.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsFrameworkBattery",
+    "name": "DMS Framework Battery",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/nfoert/dms-framework-battery",
+    "author": "nfoert",
+    "description": "Dank Material Shell battery widget, with support for changing the charge limit on Framework laptops",
+    "dependencies": ["ectool"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/nfoert/dms-framework-battery/blob/main/repo/images/image.png?raw=true"
+}


### PR DESCRIPTION
https://github.com/nfoert/dms-framework-battery

This plugin serves as a replacement for the default battery widget, adding functionality for setting the battery charge limit on Framework laptops. Charge limits can be set by presets or custom values.

This also allows the battery time remaining (or time to charge) and wattage to be displayed in the bar widget.