### PR TITLE
nix: cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,15 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766870016,
-        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
-        "type": "github"
+        "lastModified": 1779877693,
+        "narHash": "sha256-24YGUZ9p3uLeDBGS5Nc8V7Rt5PaRg1vZ+rnfSuBW7hM=",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1006043.4100e830e085/nixexprs.tar.xz"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,25 @@
 {
 
   inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
-  outputs = { self, nixpkgs, ... }:
+  outputs =
+    { self, nixpkgs, ... }:
     let
       inherit (nixpkgs) lib;
-      systems = [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
     in
     {
       checks = self.packages;
-      packages = lib.genAttrs systems (system:
+      packages = lib.genAttrs systems (
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-        in import ./nix/default.nix { inherit pkgs; }
+        in
+        import ./nix/default.nix { inherit pkgs; }
       );
       nixosModules.dms-plugin-registry = ./nix/module.nix;
       nixosModules.default = self.nixosModules.dms-plugin-registry;

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
-
   inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+
   outputs =
     { self, nixpkgs, ... }:
     let
@@ -11,16 +11,13 @@
         "x86_64-darwin"
         "x86_64-linux"
       ];
+      forEachSystem = lib.genAttrs systems;
+      pkgsForEach = nixpkgs.legacyPackages;
     in
     {
       checks = self.packages;
-      packages = lib.genAttrs systems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        import ./nix/default.nix { inherit pkgs; }
-      );
+      packages = forEachSystem (system: import ./nix/default.nix { pkgs = pkgsForEach.${system}; });
+
       nixosModules = {
         dms-plugin-registry = ./nix/module.nix;
         default = self.nixosModules.dms-plugin-registry;
@@ -30,6 +27,6 @@
         default = self.homeModules.dms-plugin-registry;
       };
 
-      formatter = lib.genAttrs systems (system: nixpkgs.legacyPackages.${system}.nixfmt);
+      formatter = lib.genAttrs systems (system: pkgsForEach.${system}.nixfmt);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,6 @@
       nixosModules.default = self.nixosModules.dms-plugin-registry;
       homeModules.dms-plugin-registry = ./nix/module.nix;
       homeModules.default = self.homeModules.dms-plugin-registry;
-      modules.dms-plugin-registry = ./nix/module.nix;
-      modules.default = self.modules.dms-plugin-registry;
 
       formatter = lib.genAttrs systems (system: nixpkgs.legacyPackages.${system}.nixfmt);
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,6 @@
 {
+
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   outputs = { self, nixpkgs, ... }:
     let
       inherit (nixpkgs) lib;

--- a/flake.nix
+++ b/flake.nix
@@ -19,5 +19,7 @@
       homeModules.default = self.homeModules.dms-plugin-registry;
       modules.dms-plugin-registry = ./nix/module.nix;
       modules.default = self.modules.dms-plugin-registry;
+
+      formatter = lib.genAttrs systems (system: nixpkgs.legacyPackages.${system}.nixfmt);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,14 @@
         in
         import ./nix/default.nix { inherit pkgs; }
       );
-      nixosModules.dms-plugin-registry = ./nix/module.nix;
-      nixosModules.default = self.nixosModules.dms-plugin-registry;
-      homeModules.dms-plugin-registry = ./nix/module.nix;
-      homeModules.default = self.homeModules.dms-plugin-registry;
+      nixosModules = {
+        dms-plugin-registry = ./nix/module.nix;
+        default = self.nixosModules.dms-plugin-registry;
+      };
+      homeModules = {
+        dms-plugin-registry = ./nix/module.nix;
+        default = self.homeModules.dms-plugin-registry;
+      };
 
       formatter = lib.genAttrs systems (system: nixpkgs.legacyPackages.${system}.nixfmt);
     };


### PR DESCRIPTION
This is a series of several independent patches; I'd advise going through them in order. 

- Add a `nixpkgs` flake input instead of impurely relying on the one the current system has. Unborks my local config, since it one assumes that things in the attrset that `outputs` takes actually exist in `inputs` (which is somehting one can generally assume).
- Add a default formatter
- Format the flake using it
- Drop the modules output. This is viable since `modules` is not a valid output of nixosModules. See [here](https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-flake-check.html#evaluation-checks) for the valid output options. 
- Some minor flake cleanup, i.e. packing module bindings into nested attrSets and cleaning up/improving the functions used for iterating over the systems. 


I'd be glad to answer any further questions if so needed. 

---
<sup><sub>No AI assistance was used in the creation of this pull request.</sub></sup>