### PR TITLE
feat: register quick-capture and drop dms-common dependencies

### DIFF
--- a/plugins/hthienloc-activate-linux.json
+++ b/plugins/hthienloc-activate-linux.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-activate-linux",
     "author": "Loc Huynh",
     "description": "Adds a watermark to the bottom-right of the screen",
-    "dependencies": ["dms-common"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-activate-linux/master/screenshot.png"

--- a/plugins/hthienloc-ambient-sound.json
+++ b/plugins/hthienloc-ambient-sound.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-ambient-sound",
     "author": "Loc Huynh",
     "description": "Play ambient focus sounds with integrated sleep timer and volume control.",
-    "dependencies": ["mpv", "socat", "dms-common"],
+    "dependencies": ["mpv", "socat"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ambient-sound/master/screenshot.png"

--- a/plugins/hthienloc-appLauncher.json
+++ b/plugins/hthienloc-appLauncher.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-app-launcher",
     "author": "Loc Huynh",
     "description": "Desktop widget to search, filter, and launch applications by categories.",
-    "dependencies": ["python3", "dms-common"],
+    "dependencies": ["python3"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-app-launcher/main/screenshot.png"

--- a/plugins/hthienloc-bongo-cat.json
+++ b/plugins/hthienloc-bongo-cat.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-bongo-cat",
     "author": "Loc Huynh",
     "description": "A reactive animated cat that taps along with your keyboard input.",
-    "dependencies": ["evtest", "libinput", "dms-common"],
+    "dependencies": ["evtest", "libinput"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-bongo-cat/main/screenshot.png"

--- a/plugins/hthienloc-breathing.json
+++ b/plugins/hthienloc-breathing.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-breathing",
     "author": "Loc Huynh",
     "description": "A guided breathing exercise tool for mindfulness and relaxation.",
-    "dependencies": ["dms-common"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-breathing/master/screenshot.png"

--- a/plugins/hthienloc-floaty.json
+++ b/plugins/hthienloc-floaty.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-floaty",
     "author": "Loc Huynh",
     "description": "A feature-rich reference image tool to float images, screenshots, and vector graphics on top of all windows.",
-    "dependencies": ["poppler-utils", "dms-common"],
+    "dependencies": ["poppler-utils"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-floaty/main/screenshot.png"

--- a/plugins/hthienloc-folderView.json
+++ b/plugins/hthienloc-folderView.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-folder-view",
     "author": "Loc Huynh",
     "description": "A folder viewer widget that displays and manages files and directories on your screen.",
-    "dependencies": ["wl-clipboard", "glib2", "dms-common"],
+    "dependencies": ["wl-clipboard", "glib2"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-folder-view/main/screenshot.png"

--- a/plugins/hthienloc-hidden-bar.json
+++ b/plugins/hthienloc-hidden-bar.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-hidden-bar",
     "author": "Loc Huynh",
     "description": "Hide/Show bar widgets with a click or hover",
-    "dependencies": ["dms-common"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-hidden-bar/master/screenshot.png"

--- a/plugins/hthienloc-hydrate.json
+++ b/plugins/hthienloc-hydrate.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-hydrate",
     "author": "Loc Huynh",
     "description": "Drink water reminder and tracker.",
-    "dependencies": ["dms-common"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-hydrate/master/screenshot.png"

--- a/plugins/hthienloc-ipIndicator.json
+++ b/plugins/hthienloc-ipIndicator.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-ipIndicator",
     "author": "Loc Huynh",
     "description": "Display public IP address, ISP, and location with a privacy-focused toggle.",
-    "dependencies": ["curl", "dms-common"],
+    "dependencies": ["curl"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ipIndicator/master/screenshot.png"

--- a/plugins/hthienloc-kaomoji-picker.json
+++ b/plugins/hthienloc-kaomoji-picker.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-kaomoji-picker",
     "author": "Loc Huynh",
     "description": "A lightweight launcher for browsing and copying kaomojis to the clipboard.",
-    "dependencies": ["wl-clipboard", "dms-common"],
+    "dependencies": ["wl-clipboard"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-kaomoji-picker/master/screenshot.png"

--- a/plugins/hthienloc-lutris-launcher.json
+++ b/plugins/hthienloc-lutris-launcher.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-lutris-launcher",
     "author": "Loc Huynh",
     "description": "Quickly browse and launch games from your Lutris library.",
-    "dependencies": ["lutris", "dms-common"],
+    "dependencies": ["lutris"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-lutris-launcher/master/screenshot.png"

--- a/plugins/hthienloc-niriDS.json
+++ b/plugins/hthienloc-niriDS.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-niri-display-settings",
     "author": "Loc Huynh",
     "description": "Quickly toggle and configure display outputs in the Niri Wayland compositor.",
-    "dependencies": ["niri", "wl-mirror", "dms-common"],
+    "dependencies": ["niri", "wl-mirror"],
     "compositors": ["niri"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-niri-display-settings/master/screenshot.png"

--- a/plugins/hthienloc-ocr-scanner.json
+++ b/plugins/hthienloc-ocr-scanner.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-ocr-scanner",
     "author": "Loc Huynh",
     "description": "Extract text from clipboard images or local files using Tesseract OCR.",
-    "dependencies": ["tesseract", "dms-common"],
+    "dependencies": ["tesseract"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-ocr-scanner/main/screenshot.png"

--- a/plugins/hthienloc-qr-generator.json
+++ b/plugins/hthienloc-qr-generator.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-qr-generator",
     "author": "Loc Huynh",
     "description": "Generate and scan QR codes from clipboard text, manual input, or dropped images.",
-    "dependencies": ["qrencode", "wl-clipboard", "zbar", "dms-common"],
+    "dependencies": ["qrencode", "wl-clipboard", "zbar"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-qr-generator/master/screenshot.png"

--- a/plugins/hthienloc-quick-capture.json
+++ b/plugins/hthienloc-quick-capture.json
@@ -1,0 +1,13 @@
+{
+    "id": "quickCapture",
+    "name": "Quick Capture",
+    "capabilities": ["daemon"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-quick-capture",
+    "author": "Loc Huynh",
+    "description": "A quick screen capture utility featuring screenshot tools, drawing, and annotation.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-quick-capture/main/screenshot.png"
+}

--- a/plugins/hthienloc-stopwatch.json
+++ b/plugins/hthienloc-stopwatch.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-stopwatch",
     "author": "Loc Huynh",
     "description": "A high-precision stopwatch for time tracking.",
-    "dependencies": ["dms-common"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-stopwatch/main/screenshot.png"

--- a/plugins/hthienloc-timer.json
+++ b/plugins/hthienloc-timer.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-timer",
     "author": "Loc Huynh",
     "description": "A countdown timer with notification support and audio alerts.",
-    "dependencies": ["libnotify", "pulseaudio", "dms-common"],
+    "dependencies": ["libnotify", "pulseaudio"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-timer/master/screenshot.png"


### PR DESCRIPTION
Removed the `dms-common` dependency from all `hthienloc` plugins since they now vendor the components via `sync_common.py`. Also registered the new `quick-capture` plugin.