### PR TITLE
Add Acer Sense plugin

### DIFF
--- a/plugins/raphamzn-acer-sense.json
+++ b/plugins/raphamzn-acer-sense.json
@@ -1,0 +1,13 @@
+{
+  "id": "acerSense",
+  "name": "Acer Sense",
+  "capabilities": ["dankbar-widget"],
+  "category": "system",
+  "repo": "https://github.com/raphamzn/dms-acer-sense",
+  "author": "raphamzn",
+  "description": "Control panel for Acer Nitro/Predator laptops: power profile, fan presets, battery charge limit, USB charging and GPU mode (envycontrol), powered by linuwu-sense.",
+  "dependencies": ["linuwu-sense"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/raphamzn/dms-acer-sense/main/screenshot.png"
+}


### PR DESCRIPTION
Adds **Acer Sense** — a control panel for **Acer Nitro / Predator** laptops.

A DankBar pill (power-profile icon + live CPU temp) opens a popout with:
- Power profile (low-power / quiet / balanced / performance)
- Fan presets (Auto / Quiet / Max)
- Battery 80% charge limit + USB charging
- GPU mode (hybrid / integrated / nvidia via `envycontrol`, with confirmation)

Hardware access is via the `linuwu-sense` kernel module (`acer-wmi`); privileged writes go through a small whitelisted `NOPASSWD` helper shipped in the repo. The discrete GPU is only queried while the popout is open, so it's never woken just to draw the bar.

- Repo: https://github.com/raphamzn/dms-acer-sense
- id/name match the repo's `plugin.json` (`acerSense` / `Acer Sense`)
- Schema validation (`generate.py --validate`) passes; screenshot URL returns 200

Tested on an Acer Nitro ANV15-51; Predator path (`predator_sense`) is auto-detected and best-effort.