### PR TITLE
Add Color Picker DMS plugin

### DIFF
--- a/plugins/bernardopg-color-picker-dms.json
+++ b/plugins/bernardopg-color-picker-dms.json
@@ -1,0 +1,13 @@
+{
+    "id": "colorPicker",
+    "name": "Color Picker DMS",
+    "capabilities": ["dankbar-widget", "control-center"],
+    "category": "utilities",
+    "repo": "https://github.com/bernardopg/color-picker-dms",
+    "author": "bernardopg",
+    "description": "Pick colors from the screen, convert common color formats, build palettes, and check WCAG contrast from DankBar",
+    "dependencies": ["wl-clipboard"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/bernardopg/color-picker-dms/main/screenshot.png"
+}


### PR DESCRIPTION
Adds Color Picker DMS to the plugin registry.

Plugin repo: https://github.com/bernardopg/color-picker-dms

Validated locally:
- python3 .github/generate.py --validate
- CHANGED_PLUGINS=plugins/bernardopg-color-picker-dms.json python3 .github/validate_links.py