### PR TITLE
Update colorPicker plugin id to colorPickerDms

### DIFF
--- a/plugins/bernardopg-color-picker-dms.json
+++ b/plugins/bernardopg-color-picker-dms.json
@@ -1,5 +1,5 @@
 {
-    "id": "colorPicker",
+    "id": "colorPickerDms",
     "name": "Color Picker DMS",
     "capabilities": ["dankbar-widget", "control-center"],
     "category": "utilities",

--- a/plugins/bernardopg-color-picker-dms.json
+++ b/plugins/bernardopg-color-picker-dms.json
@@ -9,5 +9,5 @@
     "dependencies": ["wl-clipboard"],
     "compositors": ["niri", "hyprland"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/bernardopg/color-picker-dms/main/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/bernardopg/color-picker-dms/main/assets/screenshot.png"
 }


### PR DESCRIPTION
## What

Updates the registry `id` for **Color Picker DMS** from `colorPicker` to `colorPickerDms` in `plugins/bernardopg-color-picker-dms.json`.

## Why

The plugin id was renamed upstream because `colorPicker` collided with the built-in DMS `colorPicker` bar widget — the collision made the DankBar render the native widget instead of the plugin, breaking its right-click menu. The plugin's `plugin.json` `id` is now `colorPickerDms` (released as v1.1.0).

Per the registry schema, the registry `id` must exactly match the repo's `plugin.json` `id`, so this entry needs the same change.

## Validation

```
python3 .github/generate.py --validate   # Validation successful!
python3 .github/validate_links.py         # exit 0
```

Confirmed the live manifest now reports the new id:
`https://raw.githubusercontent.com/bernardopg/color-picker-dms/main/plugin.json` → `"id": "colorPickerDms"`.