### PR TITLE
feat: add Hyprland Submap Indicator plugin

### DIFF
--- a/plugins/nderscore-hyprlandsubmapindicator.json
+++ b/plugins/nderscore-hyprlandsubmapindicator.json
@@ -1,0 +1,14 @@
+{
+    "id": "hyprlandSubmapIndicator",
+    "name": "Hyprland Submap Indicator",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/nderscore/dms-plugins",
+    "path": "HyprlandSubmapIndicator",
+    "author": "_nderscore",
+    "description": "Shows a customizable indicator when a Hyprland submap is active",
+    "dependencies": [],
+    "compositors": ["hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/nderscore/dms-plugins/main/assets/HyprlandSubmapIndicator-screenshot.png"
+}


### PR DESCRIPTION
This PR adds a statusbar widget plugin "**Hyprland Submap Indicator**" with ID `hyprlandSubmapIndicator`

Source: https://github.com/nderscore/dms-plugins/tree/main/HyprlandSubmapIndicator