### PR TITLE
Add animationRotate - Niri animation rotation control widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -2068,6 +2068,28 @@ Play ambient focus sounds with integrated sleep timer and volume control.
 
 
 
+#### [Animation Rotate](https://github.com/pnbarbeito/dank-niri-animation-rotate)
+
+Control niri-animation-rotate from the Control Center: switch animations, change modes, and filter events. Daemon included — batteries included.
+
+![screenshot](https://raw.githubusercontent.com/pnbarbeito/dms-niri-animation-rotate/f66b0ef7a1bb46e018d57c4cc8acccab17797d84/screenshots/widget.png)
+
+<strong>requires DMS version</strong>: <em>>=1.4.0</em>
+
+- id: animationRotate
+- name: Animation Rotate
+- author: pnbarbeito
+- compositors: niri
+- capabilities: control-center, dankbar-widget
+- dependencies: niri
+- distro: any
+
+
+
+
+
+
+
 #### [Anime Calendar](https://github.com/RiceaRaul/DMS-AnimeCalendarPlugin)
 
 A QuickShell plugin for DankMaterialShell that tracks anime episode releases and sends notifications when your favorite shows air.
@@ -6519,5 +6541,3 @@ Retrobox dark theme with retro groove colors
 - **ID:** `retrobox` **Version:** `1.0.0`
 
 ![retrobox](themes/retrobox/preview.svg)
-
-

--- a/README.md
+++ b/README.md
@@ -2068,7 +2068,7 @@ Play ambient focus sounds with integrated sleep timer and volume control.
 
 
 
-#### [Animation Rotate](https://github.com/pnbarbeito/dank-niri-animation-rotate)
+#### [Animation Rotate](https://github.com/pnbarbeito/dms-niri-animation-rotate)
 
 Control niri-animation-rotate from the Control Center: switch animations, change modes, and filter events. Daemon included — batteries included.
 

--- a/README.md
+++ b/README.md
@@ -2072,8 +2072,6 @@ Play ambient focus sounds with integrated sleep timer and volume control.
 
 Control niri-animation-rotate from the Control Center: switch animations, change modes, and filter events. Daemon included — batteries included.
 
-![screenshot](https://raw.githubusercontent.com/pnbarbeito/dms-niri-animation-rotate/f66b0ef7a1bb46e018d57c4cc8acccab17797d84/screenshots/widget.png)
-
 <strong>requires DMS version</strong>: <em>>=1.4.0</em>
 
 - id: animationRotate
@@ -2085,6 +2083,15 @@ Control niri-animation-rotate from the Control Center: switch animations, change
 - distro: any
 
 
+
+
+
+<details>
+<summary>Screenshot</summary>
+
+![screenshot](https://raw.githubusercontent.com/pnbarbeito/dms-niri-animation-rotate/f66b0ef7a1bb46e018d57c4cc8acccab17797d84/screenshots/widget.png)
+
+</details>
 
 
 
@@ -6541,3 +6548,5 @@ Retrobox dark theme with retro groove colors
 - **ID:** `retrobox` **Version:** `1.0.0`
 
 ![retrobox](themes/retrobox/preview.svg)
+
+

--- a/plugins/animationRotate.json
+++ b/plugins/animationRotate.json
@@ -1,0 +1,13 @@
+{
+  "id": "animationRotate",
+  "name": "Animation Rotate",
+  "capabilities": ["control-center", "dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/pnbarbeito/dank-niri-animation-rotate",
+  "author": "pnbarbeito",
+  "description": "Control niri-animation-rotate from the Control Center: switch animations, change modes, and filter events. Daemon included — batteries included.",
+  "dependencies": ["niri"],
+  "compositors": ["niri"],
+  "distro": ["any"],
+  "requires_dms": ">=1.4.0"
+}

--- a/plugins/animationRotate.json
+++ b/plugins/animationRotate.json
@@ -3,11 +3,12 @@
   "name": "Animation Rotate",
   "capabilities": ["control-center", "dankbar-widget"],
   "category": "utilities",
-  "repo": "https://github.com/pnbarbeito/dank-niri-animation-rotate",
+  "repo": "https://github.com/pnbarbeito/dms-niri-animation-rotate",
   "author": "pnbarbeito",
   "description": "Control niri-animation-rotate from the Control Center: switch animations, change modes, and filter events. Daemon included — batteries included.",
   "dependencies": ["niri"],
   "compositors": ["niri"],
   "distro": ["any"],
-  "requires_dms": ">=1.4.0"
+  "requires_dms": ">=1.4.0",
+  "screenshot": "https://raw.githubusercontent.com/pnbarbeito/dms-niri-animation-rotate/f66b0ef7a1bb46e018d57c4cc8acccab17797d84/screenshots/widget.png"
 }


### PR DESCRIPTION
Plugin to control `niri-animation-rotate` from Dank Material Shell.

## What it does
- Cycle through Niri window animations with prev/next buttons
- Pick any animation from a dropdown selector
- Toggle between Auto (event-driven) and Manual mode
- Filter window-open and window-close events
- DankBar pill showing the current animation name
- Popout panel (380×640) with all controls

## How it works
The Rust daemon (`niri-animation-rotate`) is statically compiled with musl and bundled inside the plugin directory. No Rust toolchain, no building, no manual daemon installation — everything is self-contained.

On first activation, the plugin auto-starts the daemon, sets up the required Niri config include (`include "dms/animation.kdl"`), and configures the output path under `~/.config/niri/dms/`.

## Requirements
- Niri compositor (v0.1.5+)
- DMS >= 1.4.0

## Repos
#### Plugin
https://github.com/pnbarbeito/dms-niri-animation-rotate
#### Daemon
https://github.com/pnbarbeito/niri-animation-rotate