### PR TITLE
feat: add desktop-widget-toggle metadata

### DIFF
--- a/plugins/hthienloc-desktop-widget-toggle.json
+++ b/plugins/hthienloc-desktop-widget-toggle.json
@@ -1,0 +1,13 @@
+{
+    "id": "desktopWidgetToggle",
+    "name": "Desktop Widget Toggle",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-desktop-widget-toggle",
+    "author": "Loc Huynh",
+    "description": "Toggle visibility of desktop widget groups as overlay",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-desktop-widget-toggle/master/screenshot.png"
+}

--- a/plugins/hthienloc-desktop-widget-toggle.json
+++ b/plugins/hthienloc-desktop-widget-toggle.json
@@ -1,7 +1,8 @@
 {
     "id": "desktopWidgetToggle",
     "name": "Desktop Widget Toggle",
-    "capabilities": ["dankbar-widget"],
+    "type": "daemon",
+    "capabilities": ["dankbar-widget", "ipc"],
     "category": "utilities",
     "repo": "https://github.com/hthienloc/dms-desktop-widget-toggle",
     "author": "Loc Huynh",


### PR DESCRIPTION
Registers the new desktop widget toggle plugin.