### PR TITLE
Add: Dank Hermes plugin

### DIFF
--- a/huangkaile22-prog-dank-hermes.json
+++ b/huangkaile22-prog-dank-hermes.json
@@ -7,7 +7,7 @@
     "author": "hkl",
     "description": "AI chat sidebar powered by local Hermes agent.",
     "dependencies": [],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://github.com/huangkaile22-prog/dankhermes/blob/main/screenshot-chat.png"
 }

--- a/huangkaile22-prog-dank-hermes.json
+++ b/huangkaile22-prog-dank-hermes.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankHermes",
+    "name": "Dank Hermes",
+    "capabilities": ["ai-chat"],
+    "category": "utilities",
+    "repo": "https://github.com/huangkaile22-prog/dankhermes",
+    "author": "hkl",
+    "description": "AI chat sidebar powered by local Hermes agent.",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/huangkaile22-prog/dankhermes/blob/main/screenshot-chat.png"
+}


### PR DESCRIPTION
Add Dank Hermes plugin

  AI chat sidebar powered by local Hermes agent. Features a slideout panel with conversation
  history, keyboard shortcut toggle (Mod+A), and Material Design 3 theming.

  Requires Hermes Agent with API server enabled.