### PR TITLE
Add dgpu sleep monitor

### DIFF
--- a/plugins/xantrk-dgpu-sleep-monitor.json
+++ b/plugins/xantrk-dgpu-sleep-monitor.json
@@ -1,0 +1,14 @@
+{
+  "id": "dgpuStatus",
+  "name": "dGPU Sleep Monitor",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/xantrk/dgpu-sleep-monitor",
+  "author": "xantrk",
+  "description": "Monitor dGPU power state (D0, D3cold) and optionally display battery wattage with toggles for cardwire and/or supergfxctl mode switching.",
+  "dependencies": [],
+  "compositors": ["niri", "hyprland"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/xantrk/dgpu-sleep-monitor/refs/heads/master/screenshots/Screenshot%20from%202026-06-08%2000-50-01.png"
+}
+


### PR DESCRIPTION
A Dank Material Shell / Quickshell plugin that monitors your discrete GPU power state and optionally displays battery wattage alongside mode-switching controls for [superggfxctl](https://gitlab.com/asus-linux/supergfxctl) and [cardwire](https://opengamingcollective.github.io/cardwire/).

<img width="469" height="562" alt="1780879118765328348" src="https://github.com/user-attachments/assets/6f4aca11-199f-4c8f-861c-c366a25739e4" />
