### PR TITLE
add: wiener linien plugin

### DIFF
--- a/plugins/wolfsblu-wienerLinien.json
+++ b/plugins/wolfsblu-wienerLinien.json
@@ -1,0 +1,13 @@
+{
+    "id": "wienerLinien",
+    "name": "Wiener Linien",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/wolfsblu/dms-wiener-linien",
+    "author": "Lukas Wolfsberger",
+    "description": "Track departure times of Wiener Linien public transit",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/wolfsblu/dms-wiener-linien/refs/heads/main/screenshot.png"
+}


### PR DESCRIPTION
Add Wiener Linien plugin

A plugin that allows users to monitor public transit departure times in their Dank bar. Data provided by the public Wiener Linien API.