### PR TITLE
Add Claude Usage plugin

### DIFF
--- a/plugins/bogdan-velicu-claude-usage.json
+++ b/plugins/bogdan-velicu-claude-usage.json
@@ -1,0 +1,13 @@
+{
+    "id": "claudeUsage",
+    "name": "Claude Usage",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/bogdan-velicu/DankClaudeUsage",
+    "author": "Bogdan Velicu",
+    "description": "Claude Code 5-hour and weekly subscription limits in your bar, as theme-colored rings with a popout. Zero setup.",
+    "dependencies": ["jq", "curl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/bogdan-velicu/DankClaudeUsage/main/assets/popout.png"
+}


### PR DESCRIPTION
Adds **Claude Usage** — a DankBar widget showing Claude Code's 5-hour and weekly subscription limits (the `/usage` numbers) as theme-colored rings with a popout.

- Repo: https://github.com/bogdan-velicu/DankClaudeUsage
- Category: monitoring · Capabilities: dankbar-widget
- Dependencies: jq, curl
- **Zero setup**: reads the OAuth token Claude Code already stores locally and queries the usage endpoint directly — no statusline wiring or config edits.

`id`/`name` match the repo's plugin.json (`claudeUsage` / `Claude Usage`). Ran `.github/generate.py --validate` → Validation successful; screenshot + repo URLs return 200.