### PR TITLE
feat: add Webcams Viewer plugin

### DIFF
--- a/plugins/antikytheraton-webcams-viewer.json
+++ b/plugins/antikytheraton-webcams-viewer.json
@@ -1,0 +1,13 @@
+{
+  "id": "webcamViewer",
+  "name": "Webcam Viewer",
+  "capabilities": ["dankbar-widget"],
+  "category": "monitoring",
+  "repo": "https://github.com/antikytheraton/DankWebcamViewer",
+  "author": "antikytheraton",
+  "description": "Shows RTSP camera streams via vlc/ffplay/mpv from the DankBar",
+  "dependencies": ["vlc", "mpv", "ffmpeg"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://github.com/antikytheraton/DankWebcamViewer/blob/main/assets/screenshot-plugin.png"
+}


### PR DESCRIPTION
A Dank Material Shell / Quickshell plugin to configure and monitor any RTSP webcam through the widget. It uses VLC by default, but you can select MPV or ffplay through the plugin settings panel.

<img width="760" height="447" alt="screenshot-plugin" src="https://github.com/user-attachments/assets/d5adbe66-df8c-4498-8500-6bced5f14b57" />
<img width="547" height="426" alt="screenshot-settings" src="https://github.com/user-attachments/assets/d8c54146-b3a8-4091-9f04-4d7da754c1c6" />
