### PR TITLE
Add Tailscale Plus plugin

### DIFF
--- a/plugins/rocho-el-locho-tailscale-plus.json
+++ b/plugins/rocho-el-locho-tailscale-plus.json
@@ -1,0 +1,23 @@
+{
+    "id": "tailscalePlus",
+    "name": "Tailscale Plus",
+    "capabilities": [
+        "dankbar-widget",
+        "control-center-widget"
+    ],
+    "category": "network",
+    "repo": "https://github.com/Rocho-EL-Locho/dms-tailscale",
+    "path": "",
+    "author": "Rocho",
+    "description": "Tailscale management widget: connection toggle, exit node picker with online state and Mullvad badges, allow-LAN-access toggle and a collapsible peer list. Extended fork of cglavin50's dms-tailscale.",
+    "dependencies": [
+        "tailscale"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://github.com/Rocho-EL-Locho/dms-tailscale/raw/main/plugin-notif.png"
+}


### PR DESCRIPTION
Adds **Tailscale Plus** — a Tailscale management widget for the DankBar.

Repo: https://github.com/Rocho-EL-Locho/dms-tailscale (extended fork of cglavin50/dms-tailscale, which is already listed but appears unmaintained)

Features beyond the original toggle-only widget:

- Popout panel with connection toggle, device info and an exit node picker (online state per node, Mullvad badge, "direct connection" entry)
- "Allow local network access" toggle while an exit node is active
- Collapsible peer list with online count
- Control center tile
- Bar pill shows the active exit node; left click opens the panel, right click quick-toggles the connection
- Shared singleton service, so multi-monitor setups run a single poll loop

`generate.py --validate` passes locally; id/name match the repository's plugin.json.