### PR TITLE
Add Mail Checker plugin

### DIFF
--- a/plugins/rocho-el-locho-mail-checker.json
+++ b/plugins/rocho-el-locho-mail-checker.json
@@ -1,0 +1,14 @@
+{
+    "id": "mailChecker",
+    "name": "Mail Checker",
+    "capabilities": ["dankbar-widget", "control-center-widget"],
+    "category": "productivity",
+    "repo": "https://github.com/Rocho-EL-Locho/dms-mail-checker",
+    "path": "",
+    "author": "Rocho",
+    "description": "Unread mail checker for IMAP mailboxes: bar indicator with unread count, popout with message list, desktop notifications. Not a mail client, just a checker.",
+    "dependencies": ["python3"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/Rocho-EL-Locho/dms-mail-checker/raw/main/docs/screenshot.png"
+}


### PR DESCRIPTION
Adds **Mail Checker** — an unread-mail checker for IMAP mailboxes, implementing the idea from #10.

Repo: https://github.com/Rocho-EL-Locho/dms-mail-checker

- Bar indicator with envelope icon, red dot and unread count
- Popout with the unread messages (sender, subject, age); clicking opens the configured mail client
- Desktop notifications on new mail, control center tile
- Stdlib-only Python helper, IMAP is opened read-only (messages are never marked as read)
- Password comes from a configurable command (secret-tool / pass / rbw / op); nothing sensitive is stored in settings or visible in the process list
- Explicitly *not* a mail client — just a checker, per the issue's non-goals

`generate.py --validate` passes locally; id/name match the repository's plugin.json; screenshot URL is reachable.