### PR TITLE
feat: add Live Lyrics plugin

### DIFF
--- a/plugins/noahpolimon-liveLyrics.json
+++ b/plugins/noahpolimon-liveLyrics.json
@@ -1,0 +1,13 @@
+{
+    "id": "liveLyrics",
+    "name": "Live Lyrics",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://gitlab.com/noahpolimon/dms-plugin-livelyrics",
+    "author": "noahpolimon",
+    "description": "Display synced lyrics on your DankBar (Music Lyrics fork)",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://gitlab.com/noahpolimon/dms-plugin-livelyrics/-/raw/main/screenshot.png"
+}


### PR DESCRIPTION
Adds the Live Lyrics plugin, a Music Lyrics fork with improved bar pill size and more control over lyrics source. It displays synced lyrics on the DankBar for currently playing music.

<img width="494" height="589" alt="image" src="https://github.com/user-attachments/assets/73f7217c-2b13-49d6-ae9d-63a4233f770f" />
<img width="569" height="953" alt="image" src="https://github.com/user-attachments/assets/3220c2fc-4cc2-4729-b66a-9dff1b1e723c" />
