### PR TITLE
Add Dropdown Menu and Widget Group plugins

### DIFF
--- a/plugins/rdannenbring-dropdown-menu.json
+++ b/plugins/rdannenbring-dropdown-menu.json
@@ -1,0 +1,13 @@
+{
+    "id": "dropdownMenu",
+    "name": "Dropdown Menu",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/rdannenbring/dropdown-menu",
+    "author": "rdannenbring",
+    "description": "Configurable bar button that opens a dropdown menu of actions, plugin toggles, popouts, and IPC commands",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rdannenbring/dropdown-menu/main/assets/dropdown-menu.png"
+}

--- a/plugins/rdannenbring-widget-group.json
+++ b/plugins/rdannenbring-widget-group.json
@@ -1,0 +1,13 @@
+{
+    "id": "widgetGroup",
+    "name": "Widget Group",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/rdannenbring/widget-group",
+    "author": "rdannenbring",
+    "description": "One bar button that expands to reveal a group of widgets inline, each with its own live pill and popout",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rdannenbring/widget-group/main/assets/group-expanded.png"
+}


### PR DESCRIPTION
Adds two bar-widget plugins:

- **Dropdown Menu** (`dropdownMenu`) — a configurable bar button that opens a dropdown menu of actions, plugin toggles, popouts, and DMS IPC commands.
  Repo: https://github.com/rdannenbring/dropdown-menu

- **Widget Group** (`widgetGroup`) — a single collapsible bar button that expands to reveal a group of widgets inline, each keeping its own live pill and working popout.
  Repo: https://github.com/rdannenbring/widget-group

Both are `dankbar-widget` plugins, compositor- and distro-agnostic, with screenshots in their repos. Validated locally with `generate.py --validate` and `validate_links.py` — both pass.