### PR TITLE
plugins: add DMS Conky (desktop-widget)

### DIFF
--- a/plugins/suruibin-dmsconky.json
+++ b/plugins/suruibin-dmsconky.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsconky",
+    "name": "DMS Conky",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/suruibin/dms-conky",
+    "author": "suruibin",
+    "description": "Classic Conky-style System Monitor + App Launcher",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/suruibin/dms-conky/main/Screenshots/promo.png"
+}


### PR DESCRIPTION
Adds [DMS Conky](https://github.com/suruibin/dms-conky), a classic Conky-style system monitor as a desktop widget plugin.

- **Type:** desktop-widget
- **Category:** utilities
- **Compositors:** any
- **Screenshot:** https://raw.githubusercontent.com/suruibin/dms-conky/main/Screenshots/promo.png