### PR TITLE
feat: add hthienloc-handMirror and update dependencies

### DIFF
--- a/plugins/hthienloc-breathing.json
+++ b/plugins/hthienloc-breathing.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-breathing",
     "author": "Loc Huynh",
     "description": "A guided breathing exercise tool for mindfulness and relaxation.",
-    "dependencies": [],
+    "dependencies": ["mpv", "socat"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-breathing/master/screenshot.png"

--- a/plugins/hthienloc-folderView.json
+++ b/plugins/hthienloc-folderView.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-folder-view",
     "author": "Loc Huynh",
     "description": "A folder viewer widget that displays and manages files and directories on your screen.",
-    "dependencies": ["wl-clipboard", "glib2"],
+    "dependencies": ["wl-clipboard", "glib2", "dms-floaty"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-folder-view/main/screenshot.png"

--- a/plugins/hthienloc-handMirror.json
+++ b/plugins/hthienloc-handMirror.json
@@ -5,7 +5,7 @@
     "category": "utilities",
     "repo": "https://github.com/hthienloc/dms-hand-mirror",
     "author": "Loc Huynh",
-    "description": "A cozy camera preview plugin inspired by the macOS Hand Mirror app. Supports digital zoom, pan, snapshot with countdown, and a pinnable floating window.",
+    "description": "Cozy camera preview with digital zoom, snapshots, and a pinnable floating window.",
     "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],

--- a/plugins/hthienloc-handMirror.json
+++ b/plugins/hthienloc-handMirror.json
@@ -1,0 +1,13 @@
+{
+    "id": "handMirror",
+    "name": "Hand Mirror",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-hand-mirror",
+    "author": "Loc Huynh",
+    "description": "A cozy camera preview plugin inspired by the macOS Hand Mirror app. Supports digital zoom, pan, snapshot with countdown, and a pinnable floating window.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-hand-mirror/main/screenshot.png"
+}

--- a/plugins/hthienloc-mediaDownloader.json
+++ b/plugins/hthienloc-mediaDownloader.json
@@ -1,0 +1,13 @@
+{
+    "id": "mediaDownloader",
+    "name": "Media Downloader",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-media-downloader",
+    "author": "Loc Huynh",
+    "description": "Download audio and video from web links using yt-dlp",
+    "dependencies": ["yt-dlp", "ffmpeg"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-media-downloader/main/screenshot.png"
+}

--- a/plugins/hthienloc-quick-capture.json
+++ b/plugins/hthienloc-quick-capture.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-quick-capture",
     "author": "Loc Huynh",
     "description": "A quick screen capture utility featuring screenshot tools, drawing, and annotation.",
-    "dependencies": [],
+    "dependencies": ["dms-floaty", "wl-clipboard", "imagemagick", "img2pdf"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-quick-capture/main/screenshot.png"

--- a/plugins/hthienloc-quick-capture.json
+++ b/plugins/hthienloc-quick-capture.json
@@ -6,6 +6,7 @@
     "repo": "https://github.com/hthienloc/dms-quick-capture",
     "author": "Loc Huynh",
     "description": "A quick screen capture utility featuring screenshot tools, drawing, and annotation.",
+    "requires_dms": ">=1.5.0",
     "dependencies": ["dms-floaty", "wl-clipboard", "imagemagick", "img2pdf"],
     "compositors": ["any"],
     "distro": ["any"],

--- a/plugins/hthienloc-typing-sounds.json
+++ b/plugins/hthienloc-typing-sounds.json
@@ -1,0 +1,13 @@
+{
+    "id": "typingSounds",
+    "name": "Typing Sounds",
+    "capabilities": ["daemon"],
+    "category": "utilities",
+    "repo": "https://github.com/hthienloc/dms-typing-sounds",
+    "author": "Loc Huynh",
+    "description": "Play mechanical keyboard sounds as you type",
+    "dependencies": ["evtest", "libinput", "ffmpeg"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/hthienloc/dms-typing-sounds/main/screenshot.png"
+}


### PR DESCRIPTION
This PR adds the metadata for the Hand Mirror plugin and updates dependencies for several other plugins:
- dms-hand-mirror: Initial registration.
- dms-breathing: Added mpv and socat for audio control.
- dms-quick-capture: Added dms-floaty, imagemagick, img2pdf, and wl-clipboard.
- dms-folder-view: Added dms-floaty.