### PR TITLE
Add dankSchedPicker - sched-ext CPU scheduler switcher(plugin)

### DIFF
--- a/plugins/sk-dev-ai-dankSchedPicker.json
+++ b/plugins/sk-dev-ai-dankSchedPicker.json
@@ -8,6 +8,5 @@
     "description": "Switch CPU schedulers (sched-ext) and power profiles from the bar. Supports all 12 scx schedulers with descriptions and 5 power modes (Auto, Gaming, PowerSave, LowLatency, Server). Requires scx_loader.",
     "dependencies": [],
     "compositors": ["any"],
-    "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/SK-DEV-AI/dankSchedPicker/main/screenshot.png"
+    "distro": ["any"]
 }

--- a/plugins/sk-dev-ai-dankSchedPicker.json
+++ b/plugins/sk-dev-ai-dankSchedPicker.json
@@ -7,6 +7,7 @@
     "author": "SK-DEV-AI",
     "description": "Switch CPU schedulers (sched-ext) and power profiles from the bar. Supports all 12 scx schedulers with descriptions and 5 power modes (Auto, Gaming, PowerSave, LowLatency, Server). Requires scx_loader.",
     "dependencies": [],
-    "compositors": ["niri", "hyprland", "dwl"],
-    "distro": ["any"]
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/SK-DEV-AI/dankSchedPicker/main/screenshot.png"
 }

--- a/plugins/sk-dev-ai-dankSchedPicker.json
+++ b/plugins/sk-dev-ai-dankSchedPicker.json
@@ -8,5 +8,6 @@
     "description": "Switch CPU schedulers (sched-ext) and power profiles from the bar. Supports all 12 scx schedulers with descriptions and 5 power modes (Auto, Gaming, PowerSave, LowLatency, Server). Requires scx_loader.",
     "dependencies": [],
     "compositors": ["any"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/SK-DEV-AI/dankSchedPicker/main/screenshot.png"
 }

--- a/plugins/sk-dev-ai-dankSchedPicker.json
+++ b/plugins/sk-dev-ai-dankSchedPicker.json
@@ -1,0 +1,12 @@
+{
+    "id": "dankSchedPicker",
+    "name": "Scheduler Picker",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/SK-DEV-AI/dankSchedPicker",
+    "author": "SK-DEV-AI",
+    "description": "Switch CPU schedulers (sched-ext) and power profiles from the bar. Supports all 12 scx schedulers with descriptions and 5 power modes (Auto, Gaming, PowerSave, LowLatency, Server). Requires scx_loader.",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland", "dwl"],
+    "distro": ["any"]
+}


### PR DESCRIPTION
## dankSchedPicker

A DMS bar plugin for switching CPU schedulers (sched-ext) and power profiles from the top bar.

**Features:**
- Displays current scheduler and mode in the bar pill
- Popout panel with all 12 supported scx schedulers
- 5 power modes: Auto, Gaming, PowerSave, LowLatency, Server
- Hover to see scheduler descriptions and use cases
- Real-time status updates every 3s

**Repo:** https://github.com/SK-DEV-AI/dankSchedPicker
**Requires:** scx_loader (CachyOS default), scxctl