### PR TITLE
Add Antigravity Usage plugin

### DIFF
--- a/plugins/feikowielsma-antigravity-usage.json
+++ b/plugins/feikowielsma-antigravity-usage.json
@@ -1,0 +1,13 @@
+{
+    "id": "antigravityUsage",
+    "name": "Antigravity Usage",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/FeikoWielsma/dms-antigravity-cli",
+    "author": "Feiko Wielsma",
+    "description": "Monitor Google Antigravity (agy) usage — the shared 5-hour and weekly limits for the Gemini and Claude/GPT model groups, with reset countdowns.",
+    "dependencies": ["agy", "jq", "curl", "secret-tool"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/FeikoWielsma/dms-antigravity-cli/main/screenshot2.png"
+}


### PR DESCRIPTION
Adds **Antigravity Usage** — a DankBar widget that monitors Google Antigravity (`agy`) usage: the shared 5-hour and weekly limits for the Gemini and Claude/GPT model groups, with reset countdowns.

- Repo: https://github.com/FeikoWielsma/dms-antigravity-cli
- `id`/`name` match the repo's `plugin.json` (`antigravityUsage` / `Antigravity Usage`)
- Category: monitoring
- Dependencies: `agy`, `jq`, `curl`, `secret-tool`
- Schema validation (`generate.py --validate`) passes; screenshot and repo URLs reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)