### PR TITLE
fix: fix the webcam screenshot

### DIFF
--- a/plugins/antikytheraton-webcams-viewer.json
+++ b/plugins/antikytheraton-webcams-viewer.json
@@ -9,5 +9,6 @@
   "dependencies": ["vlc", "mpv", "ffmpeg"],
   "compositors": ["any"],
   "distro": ["any"],
-  "screenshot": "https://github.com/antikytheraton/DankWebcamViewer/blob/main/assets/screenshot-plugin.png"
+  "screenshot": "https://raw.githubusercontent.com/antikytheraton/DankWebcamViewer/main/assets/screenshot.png",
+  "requires_dms": ">=0.3.0"
 }


### PR DESCRIPTION
the plugin screenshot is not showing correcly for Webcam Viewer

<img width="447" height="591" alt="Screenshot from 2026-06-15 20-30-39" src="https://github.com/user-attachments/assets/2654f965-afe4-4603-8e8a-598aa10a0ed7" />
