### PR TITLE
Add DMS Last.fm Scrobbler plugin

### DIFF
--- a/plugins/arqueon-lastfm-scrobbler.json
+++ b/plugins/arqueon-lastfm-scrobbler.json
@@ -1,0 +1,24 @@
+{
+    "id": "lastfmScrobbler",
+    "name": "DMS Last.fm Scrobbler",
+    "version": "1.1.0",
+    "capabilities": [
+        "dankbar-widget",
+        "control-center",
+        "ipc"
+    ],
+    "category": "media",
+    "repo": "https://github.com/arqueon/dms-scrobbler",
+    "author": "arqueon",
+    "description": "Scrobble MPRIS music to Last.fm, love/unlove tracks from the bar or via IPC, with media controls, album art, scrobble progress, an offline retry queue, and a live audio visualizer.",
+    "dependencies": [
+        "python3"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-scrobbler/main/assets/screenshot.png"
+}

--- a/plugins/arqueon-screenrecorder.json
+++ b/plugins/arqueon-screenrecorder.json
@@ -7,7 +7,7 @@
     "category": "utilities",
     "repo": "https://github.com/arqueon/dms-screen-recorder",
     "author": "arqueon",
-    "description": "Start, stop, and configure screen captures with gpu-screen-recorder (Wayland: niri, Hyprland, etc.)",
+    "description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor. Supports IPC keybinds.",
     "dependencies": [
         "gpu-screen-recorder"
     ],


### PR DESCRIPTION
Adds the **DMS Last.fm Scrobbler** plugin to the registry.

Scrobble MPRIS music to Last.fm, love/unlove tracks from the bar or via IPC, with media controls, album art, scrobble progress, an offline retry queue, and a live audio visualizer.

- **Repo:** https://github.com/arqueon/dms-scrobbler
- **id/name** match the plugin's `plugin.json` (`lastfmScrobbler` / `DMS Last.fm Scrobbler`)
- **Category:** media
- **Dependencies:** python3 (standard library only)
- **Compositors/Distro:** any
- Screenshot hosted in the plugin repo (`assets/screenshot.png`)

Validated locally with `python3 .github/generate.py --validate` (Validation successful). Repo and screenshot URLs return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)