### PR TITLE
Add HamQSL Propagation plugin

### DIFF
--- a/plugins/devnullvoid-hamqsl-propagation.json
+++ b/plugins/devnullvoid-hamqsl-propagation.json
@@ -1,0 +1,14 @@
+{
+  "id": "hamqslPropagation",
+  "name": "HamQSL Propagation",
+  "capabilities": ["dankbar-widget", "ham-radio", "propagation"],
+  "category": "monitoring",
+  "repo": "https://github.com/devnullvoid/dms-hamqsl-propagation",
+  "author": "devnullvoid",
+  "description": "Display HamQSL solar-terrestrial and ham radio propagation data in DankBar with compact bar modes and a detailed popout",
+  "dependencies": [],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "requires_dms": ">=0.0.28",
+  "screenshot": "https://raw.githubusercontent.com/devnullvoid/dms-hamqsl-propagation/main/screenshot.svg"
+}


### PR DESCRIPTION
## Summary

Adds the HamQSL Propagation plugin to the DMS plugin registry.

The plugin displays HamQSL solar-terrestrial and ham radio propagation data in DankBar, with compact bar display modes and a detailed popout for HF/VHF conditions and solar indices.

<img width="387" height="415" alt="image" src="https://github.com/user-attachments/assets/4b97f0ae-4aec-41e4-b919-97618769e707" />


## Validation

- `python3 .github/generate.py --validate`
- Targeted `validate_links.py` validation for `plugins/devnullvoid-hamqsl-propagation.json`
- Full `validate_links.py` scan reached this new plugin and reported it as OK before being interrupted on unrelated existing entries
