### PR TITLE
Add AI Usage plugin (Codex + Claude Code usage in DankBar)

### DIFF
--- a/plugins/darjss-ai-usage.json
+++ b/plugins/darjss-ai-usage.json
@@ -8,5 +8,6 @@
     "description": "Shows Codex and Claude Code usage limits in the DankBar",
     "dependencies": ["sqlite3"],
     "compositors": ["any"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/darjss/dms-bar-usage/main/screenshot.png"
 }

--- a/plugins/darjss-ai-usage.json
+++ b/plugins/darjss-ai-usage.json
@@ -1,0 +1,12 @@
+{
+    "id": "aiUsage",
+    "name": "AI Usage",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/darjss/dms-bar-usage",
+    "author": "darjs",
+    "description": "Shows Codex and Claude Code usage limits in the DankBar",
+    "dependencies": ["sqlite3"],
+    "compositors": ["any"],
+    "distro": ["any"]
+}

--- a/plugins/darjss-ai-usage.json
+++ b/plugins/darjss-ai-usage.json
@@ -9,5 +9,5 @@
     "dependencies": ["sqlite3"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/darjss/dms-bar-usage/main/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/darjss/dms-bar-usage/master/screenshot.png"
 }


### PR DESCRIPTION
## AI Usage

A DankMaterialShell bar widget that shows **Codex** and **Claude Code** usage limits in the DankBar. Click the robot icon for a compact 2-column popout with per-window usage bars, reset countdowns, and credit balances.

### Features
- Codex: 5-hour window, weekly window, and credit balance
- Claude Code: 5-hour session, weekly (all models), model-specific weekly (Sonnet/Opus), and extra usage / spend credits
- Color-coded status bars (green / amber / red) based on usage percentage
- Auto-refresh with configurable interval (2–60 s)
- Toggle individual providers or the credits card from settings
- Two-column compact popout layout
- Reads tokens directly from local `~/.codex` and `~/.claude` dirs — no API keys to configure

### Plugin info
- **Repo:** https://github.com/darjss/dms-bar-usage
- **id:** `aiUsage` (matches `plugin.json`)
- **name:** `AI Usage` (matches `plugin.json`)
- **Compositors:** any
- **Dependencies:** `sqlite3` (Codex fallback path reads `~/.codex/logs_2.sqlite`)

### Notes
The plugin ships a Go binary (`dms-ai-usage`) that fetches usage from both providers and prints JSON to stdout. The QML widget polls it on a timer. I'll add a screenshot before this gets merged — wanted to get the registry entry in first.