### PR TITLE
feat: add mailReader plugin

### DIFF
--- a/plugins/smithyyang-mail-reader.json
+++ b/plugins/smithyyang-mail-reader.json
@@ -1,0 +1,13 @@
+{
+    "id": "mailReader",
+    "name": "Mail Reader",
+    "capabilities": ["dankbar-widget", "control-center-widget"],
+    "category": "productivity",
+    "repo": "https://github.com/smithyyang/dms-mail-reader",
+    "author": "youngshine",
+    "description": "IMAP mail reader with built-in email content viewer. Read emails directly inside the shell without opening a separate mail client. Forked from Rocho's mailChecker.",
+    "dependencies": ["python3"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/smithyyang/dms-mail-reader/main/assets/screenshot.png"
+}

--- a/plugins/smithyyang-mail-reader.json
+++ b/plugins/smithyyang-mail-reader.json
@@ -5,7 +5,7 @@
     "category": "productivity",
     "repo": "https://github.com/smithyyang/dms-mail-reader",
     "author": "youngshine",
-    "description": "IMAP mail reader with built-in email content viewer. Read emails directly inside the shell without opening a separate mail client. Forked from Rocho's mailChecker.",
+    "description": "IMAP mail reader with built-in email content viewer, server-side read status, and attachment opening. Forked from Rocho's mailChecker.",
     "dependencies": ["python3"],
     "compositors": ["any"],
     "distro": ["any"],


### PR DESCRIPTION
## Mail Reader for DankMaterialShell

IMAP mail reader plugin with built-in email content viewer. Read emails directly inside the shell without opening a separate mail client.

### Features
- Bar indicator with unread mail count
- Popout message list with sender, subject, and relative time
- **Built-in email content viewer** — click any message to read its full content directly inside the plugin
- **Server-side read status** — opening a message marks it as read on the IMAP server
- **Attachment support** — attachments are saved to a temporary local directory and opened via xdg-open
- Desktop notifications for new mail
- Configurable display count (0 = all, x = latest x)
- Flexible polling (auto-check or manual-only mode)
- Safe listing with BODY.PEEK
- Password via command — credentials never stored in settings

### Forked from
This plugin is forked from [Rocho's mailChecker](https://github.com/Rocho-EL-Locho/dms-mail-checker) with significant enhancements:
- Added built-in email content viewer (click to read full message)
- Added server-side mark-as-read behavior when opening messages
- Added attachment extraction/opening via temporary files
- Added configurable display count
- Added manual-only refresh mode (Check Interval = 0)
- Removed mail client launch dependency

### Screenshot
![screenshot](https://raw.githubusercontent.com/smithyyang/dms-mail-reader/main/assets/screenshot.png)

### Dependencies
- python3 (with imaplib — included in standard library)