### PR TITLE
Add dcalUpcoming plugin

### DIFF
--- a/plugins/leoamaro01-dms-dcal.json
+++ b/plugins/leoamaro01-dms-dcal.json
@@ -1,0 +1,12 @@
+{
+    "id": "dcalUpcoming",
+    "name": "Dcal Upcoming Event",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/leoamaro01/dms-dcal",
+    "author": "leoamaro01",
+    "description": "Shows your next calendar event from dcal with a live countdown timer. Displays event name and time remaining, with Now indicator for current events. Click to toggle dcal UI.",
+    "dependencies": ["dcal", "jq"],
+    "compositors": ["any"],
+    "distro": ["any"]
+}

--- a/plugins/leoamaro01-dms-dcal.json
+++ b/plugins/leoamaro01-dms-dcal.json
@@ -8,5 +8,6 @@
     "description": "Shows your next calendar event from dcal with a live countdown timer. Displays event name and time remaining, with Now indicator for current events. Click to toggle dcal UI.",
     "dependencies": ["dcal", "jq"],
     "compositors": ["any"],
-    "distro": ["any"]
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/leoamaro01/dms-dcal/main/screenshot.png"
 }


### PR DESCRIPTION
Dcal upcoming event widget for the DankBar.

Shows the next calendar event from [dcal](https://github.com/leoamaro01/dms-dcal) with a live countdown timer. Displays event name and time remaining (XdYhZm format), with a green "Now" indicator for current events. Click the widget to toggle the dcal calendar UI.

**Dependencies:** dcal, jq