### PR TITLE
plugins: add DMS File Manager (desktop-widget)

### DIFF
--- a/plugins/suruibin-dmsconky.json
+++ b/plugins/suruibin-dmsconky.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsconky",
+    "name": "DMS Conky",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/suruibin/dms-conky",
+    "author": "suruibin",
+    "description": "Classic Conky-style System Monitor + App Launcher",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/suruibin/dms-conky/main/Screenshots/promo.png"
+}

--- a/plugins/suruibin-dmsfilemanager.json
+++ b/plugins/suruibin-dmsfilemanager.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsfilemanager",
+    "name": "DMS File Manager",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/suruibin/dms-filemanager",
+    "author": "suruibin",
+    "description": "File Manager For DMS - browse, manage and organize files on your desktop",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/suruibin/dms-filemanager/main/Screenshots/screenshot.png"
+}


### PR DESCRIPTION
Adds [DMS File Manager](https://github.com/suruibin/dms-filemanager), a file manager desktop widget for DankMaterialShell.

- **Type:** desktop-widget
- **Category:** utilities
- **Compositors:** any
- **Screenshot:** https://raw.githubusercontent.com/suruibin/dms-filemanager/main/Screenshots/screenshot.png