### PR TITLE
create jankelemen-display-profile-manager.json

### DIFF
--- a/plugins/jankelemen-display-profile-manager.json
+++ b/plugins/jankelemen-display-profile-manager.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/jankelemen/dank-display-profile-manager",
     "author": "Jan Kelemen",
     "description": "DankBar widget for selecting DMS output profiles.",
-    "dependencies": ["dms"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/jankelemen/dank-display-profile-manager/master/assets/screenshot.png"

--- a/plugins/jankelemen-display-profile-manager.json
+++ b/plugins/jankelemen-display-profile-manager.json
@@ -1,0 +1,13 @@
+{
+    "id": "displayProfileManager",
+    "name": "Display Profile Manager",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/jankelemen/dank-display-profile-manager",
+    "author": "Jan Kelemen",
+    "description": "DankBar widget for selecting DMS output profiles.",
+    "dependencies": ["dms"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/jankelemen/dank-display-profile-manager/master/assets/screenshot.png"
+}


### PR DESCRIPTION
DankBar widget for selecting DMS output profiles (profiles that can be set manually in settings->Displays->Configuration).
It also periodically polls "dms ipc outputs listProfiles" to always display current into.  The poll interval can be configured.