### PR TITLE
fix: skip plugin link validation for non-plugin PRs

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -49,16 +49,24 @@ jobs:
           if [ -n "$CI_CHANGED" ]; then
             echo "CI scripts changed, validating all plugins"
             echo "files=" >> "$GITHUB_OUTPUT"
+            echo "should_validate=true" >> "$GITHUB_OUTPUT"
           else
             CHANGED=$(echo "$ALL_CHANGED" | grep '^plugins/' || true)
-            echo "files<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$CHANGED" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
+            if [ -n "$CHANGED" ]; then
+              echo "files<<EOF" >> "$GITHUB_OUTPUT"
+              echo "$CHANGED" >> "$GITHUB_OUTPUT"
+              echo "EOF" >> "$GITHUB_OUTPUT"
+              echo "should_validate=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "No plugin or CI files changed, skipping plugin validation"
+              echo "should_validate=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate plugin links and paths
+        if: steps.changed.outputs.should_validate == 'true'
         id: validate-links
         run: |
           python3 .github/validate_links.py 2>&1 | tee /tmp/validate-links-output.txt


### PR DESCRIPTION
## Summary

- PRs that don't touch `plugins/` or `.github/` files (e.g. theme-only PRs like #582) were running `validate_links.py` against every plugin, causing failures from unrelated plugin issues
- The root cause was that the workflow couldn't distinguish "CI files changed, validate all" from "no relevant files changed" - both produced an empty `CHANGED_PLUGINS`
- Added a `should_validate` output flag so the validation step is skipped entirely when neither `plugins/` nor `.github/` files were modified

## Test plan

- [ ] Verify this PR's own CI passes (no plugin files changed, so plugin validation should be skipped)
- [ ] Verify a plugin-changing PR still runs validation as before
- [ ] Verify a `.github/` changing PR still validates all plugins