### PR TITLE
fix: scope plugin link validation to changed plugins only

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -45,22 +45,15 @@ jobs:
         id: changed
         run: |
           ALL_CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
-          CI_CHANGED=$(echo "$ALL_CHANGED" | grep '^\.github/' || true)
-          if [ -n "$CI_CHANGED" ]; then
-            echo "CI scripts changed, validating all plugins"
-            echo "files=" >> "$GITHUB_OUTPUT"
+          CHANGED=$(echo "$ALL_CHANGED" | grep '^plugins/' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
             echo "should_validate=true" >> "$GITHUB_OUTPUT"
           else
-            CHANGED=$(echo "$ALL_CHANGED" | grep '^plugins/' || true)
-            if [ -n "$CHANGED" ]; then
-              echo "files<<EOF" >> "$GITHUB_OUTPUT"
-              echo "$CHANGED" >> "$GITHUB_OUTPUT"
-              echo "EOF" >> "$GITHUB_OUTPUT"
-              echo "should_validate=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "No plugin or CI files changed, skipping plugin validation"
-              echo "should_validate=false" >> "$GITHUB_OUTPUT"
-            fi
+            echo "No plugin files changed, skipping plugin link validation"
+            echo "should_validate=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #584. The previous fix skipped validation when no plugins or CI files changed, but still validated ALL plugins when `.github/` files changed. This caused CI to fail on pre-existing issues (e.g. `arqueon-weekly-calendar.json` name/id mismatch) that have nothing to do with the PR.

- Removes the "CI scripts changed, validate all plugins" behavior
- Plugin link validation now only runs when `plugins/` files are modified, and only validates those specific files
- CI script changes are already exercised by the other workflow steps (schema validation, README generation, theme validation)

## Test plan

- [ ] Verify this PR's CI passes (no plugin files changed, so plugin link validation should be skipped)
- [ ] Verify a plugin-changing PR still validates the changed plugin