### PR TITLE
Add DMS Theme Sync plugin

### DIFF
--- a/plugins/arqueon-dms-theme-sync.json
+++ b/plugins/arqueon-dms-theme-sync.json
@@ -1,0 +1,23 @@
+{
+    "id": "dmsThemeSync",
+    "name": "DMS Theme Sync",
+    "capabilities": [
+        "dankbar-widget",
+        "daemon",
+        "ipc"
+    ],
+    "category": "appearance",
+    "repo": "https://github.com/arqueon/dms-theme-sync",
+    "author": "arqueon",
+    "description": "Make DMS the source of truth for appearance and propagate it to GTK, Qt, KDE, Fontconfig and XWayland apps — theme, light/dark, fonts, sizes, icons and cursor.",
+    "dependencies": [
+        "bash"
+    ],
+    "compositors": [
+        "niri"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-theme-sync/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds **DMS Theme Sync** — a cross-toolkit theme synchronization plugin for DMS.

It makes DMS the source of truth for appearance and propagates it to GTK2/3/4, Qt5/6, KDE, Fontconfig and XSettings/XWayland apps (theme, light/dark, Matugen palette, fonts, sizes, icons and cursor). Includes a bar widget, a standalone config dialog, restorable backups, and a Niri-native environment include.

- Repo: https://github.com/arqueon/dms-theme-sync
- License: GPL-3.0-or-later
- Compositor: Niri

Validated locally with `generate.py --validate` (successful) and the entry's repo + screenshot URLs return 200; `id`/`name` match the repository's plugin.json.