### PR TITLE
feat: add osvaldx-audio-port-switcher plugin

### DIFF
--- a/plugins/osvaldx-audio-port-switcher.json
+++ b/plugins/osvaldx-audio-port-switcher.json
@@ -1,0 +1,13 @@
+{
+    "id": "audioPortSwitcher",
+    "name": "Audio Port Switcher",
+    "capabilities": ["dankbar-widget"],
+    "category": "audio",
+    "repo": "https://github.com/osvaldx/Audio-Port-Switcher",
+    "author": "osvaldx",
+    "description": "Switch audio ports on a 3.5mm combo jack (internal mic vs headset mic) dynamically using PipeWire (pactl).",
+    "dependencies": [],
+    "compositors": ["hyprland", "niri"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/osvaldx/Audio-Port-Switcher/refs/heads/main/previews/settings.png"
+}

--- a/plugins/osvaldx-audio-port-switcher.json
+++ b/plugins/osvaldx-audio-port-switcher.json
@@ -5,7 +5,7 @@
     "category": "audio",
     "repo": "https://github.com/osvaldx/Audio-Port-Switcher",
     "author": "osvaldx",
-    "description": "Switch audio ports on a 3.5mm combo jack (internal mic vs headset mic) dynamically using PipeWire (pactl).",
+    "description": "Switch audio ports on a 3.5mm combo jack (internal mic vs headset mic) dynamically.",
     "dependencies": [],
     "compositors": ["hyprland", "niri"],
     "distro": ["any"],

--- a/plugins/osvaldx-audio-port-switcher.json
+++ b/plugins/osvaldx-audio-port-switcher.json
@@ -7,7 +7,7 @@
     "author": "osvaldx",
     "description": "Switch audio ports on a 3.5mm combo jack (internal mic vs headset mic) dynamically.",
     "dependencies": [],
-    "compositors": ["hyprland", "niri"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/osvaldx/Audio-Port-Switcher/refs/heads/main/previews/settings.png"
 }

--- a/plugins/osvaldx-audio-port-switcher.json
+++ b/plugins/osvaldx-audio-port-switcher.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/osvaldx/Audio-Port-Switcher",
     "author": "osvaldx",
     "description": "Switch audio ports on a 3.5mm combo jack (internal mic vs headset mic) dynamically.",
-    "dependencies": [],
+    "dependencies": ["pactl"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/osvaldx/Audio-Port-Switcher/refs/heads/main/previews/settings.png"


### PR DESCRIPTION
This widget allows you to switch between your laptop's built-in microphone and a connected headset microphone on a 3.5mm jack with a single click. It works dynamically by detecting the exact audio ports your computer uses, and it updates instantly when you plug or unplug your headphones. It serves to quickly change your active audio input right from your status bar.