### PR TITLE
[Hostname Widget] Remove redundant dms dependency

### DIFF
--- a/plugins/irunatbullets-hostname-widget.json
+++ b/plugins/irunatbullets-hostname-widget.json
@@ -6,7 +6,7 @@
   "repo": "https://github.com/irunatbullets/hostname-widget",
   "author": "irunatbullets",
   "description": "A widget for displaying your hostname",
-  "dependencies": ["dms"],
+  "dependencies": [],
   "compositors": ["any"],
   "distro": ["any"],
   "screenshot": "https://raw.githubusercontent.com/irunatbullets/hostname-widget/main/assets/screenshot.png"


### PR DESCRIPTION
`irunatbullets-hostname-widget.json` used to have `dms` as a dependency, but it's not really necessary.