### PR TITLE
Add Screen Off plugin

### DIFF
--- a/plugins/sakuratoerii-screen-off.json
+++ b/plugins/sakuratoerii-screen-off.json
@@ -1,0 +1,13 @@
+{
+    "id": "screenOff",
+    "name": "Screen Off",
+    "capabilities": ["dankbar-widget", "control-center"],
+    "category": "system",
+    "repo": "https://github.com/SakuraToErii/DmsScreenOff",
+    "author": "Ordis",
+    "description": "Turn off monitors from DankBar or Control Center.",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland", "sway", "labwc"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/SakuraToErii/DmsScreenOff/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds Screen Off, a small DMS plugin for turning off monitors from DankBar or Control Center.

  Validation:
  - python .github/generate.py --validate
  - validate_links.py targeted check for plugins/sakuratoerii-screen-off.json