### PR TITLE
Add Dankscale plugin

### DIFF
--- a/plugins/dwright134-dankscale.json
+++ b/plugins/dwright134-dankscale.json
@@ -7,7 +7,7 @@
     "author": "dwright",
     "description": "Manage your Tailscale network: connect/disconnect, switch accounts, copy device IPs, pick exit nodes, manage routes, and control DNS",
     "dependencies": ["tailscale"],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/dwright134/dms-dankscale/main/docs/screenshot.png"
 }

--- a/plugins/dwright134-dankscale.json
+++ b/plugins/dwright134-dankscale.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankscale",
+    "name": "Dankscale",
+    "capabilities": ["dankbar-widget", "control-center", "vpn", "network"],
+    "category": "utilities",
+    "repo": "https://github.com/dwright134/dms-dankscale",
+    "author": "dwright",
+    "description": "Manage your Tailscale network: connect/disconnect, switch accounts, copy device IPs, pick exit nodes, manage routes, and control DNS",
+    "dependencies": ["tailscale"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/dwright134/dms-dankscale/main/docs/screenshot.png"
+}


### PR DESCRIPTION
Adds **Dankscale**, a Tailscale network manager for the DankMaterialShell bar — a Linux stand-in for the macOS Tailscale menu-bar app.

- **Repo:** https://github.com/dwright134/dms-dankscale
- **Capabilities:** dankbar-widget, control-center
- **Category:** utilities
- **Dependencies:** `tailscale` (CLI with `tailscaled` running)
- **Compositors:** niri, hyprland

Features: connect/disconnect toggle, account switching, copy device IPs/MagicDNS names, exit-node selection, subnet-route management, and DNS control, plus a full manager modal.

Validated locally with `.github/generate.py --validate` (passed). `id`/`name` match the repo's `plugin.json`, and the screenshot/repo URLs are reachable (HTTP 200).