### PR TITLE
Add Whisperer plugin

### DIFF
--- a/plugins/dwright134-whisperer.json
+++ b/plugins/dwright134-whisperer.json
@@ -1,0 +1,14 @@
+{
+    "id": "whisperer",
+    "name": "Whisperer",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/dwright134/dms-whisperer",
+    "path": "",
+    "author": "dwright134",
+    "description": "Voice dictation: records your voice, transcribes it locally with whisper.cpp, and types the result at the cursor. Optional cloud AI (OpenRouter / Gemini) transcribes and formats in one pass.",
+    "dependencies": ["pipewire", "ffmpeg", "wtype", "whisper.cpp", "libsecret"],
+    "compositors": ["niri", "hyprland", "sway"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/dwright134/dms-whisperer/main/docs/popout.png"
+}

--- a/plugins/dwright134-whisperer.json
+++ b/plugins/dwright134-whisperer.json
@@ -8,7 +8,7 @@
     "author": "dwright134",
     "description": "Voice dictation: records your voice, transcribes it locally with whisper.cpp, and types the result at the cursor. Optional cloud AI (OpenRouter / Gemini) transcribes and formats in one pass.",
     "dependencies": ["pipewire", "ffmpeg", "wtype", "whisper.cpp", "libsecret"],
-    "compositors": ["niri", "hyprland", "sway"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/dwright134/dms-whisperer/main/docs/popout.png"
 }


### PR DESCRIPTION
Adds **Whisperer** — voice dictation for DankMaterialShell.

Records your voice, transcribes it locally with whisper.cpp, and types the result at the focused cursor (plus clipboard). Optional cloud AI transcription (OpenRouter / Google Gemini) transcribes *and* formats in one pass.

- **Repo:** https://github.com/dwright134/dms-whisperer (release `v0.3.0`)
- **Category:** utilities
- **Capabilities:** dankbar-widget (also exposes an IPC target for `toggle`/`toggleAi`/`start`/`stop`/`cancel`/`status`)
- **Deps:** pipewire, ffmpeg, wtype, whisper.cpp, libsecret
- **Compositors:** niri, hyprland, sway (DMS-generic — wlr-layer-shell + wtype + PipeWire; tested on niri)

Validated locally with `python3 .github/generate.py --validate` and `python3 .github/validate_links.py` (both pass). `id`/`name` match the repo's `plugin.json`.