### PR TITLE
Add Battery Plus plugin

### DIFF
--- a/plugins/arcatva-battery-plus.json
+++ b/plugins/arcatva-battery-plus.json
@@ -1,0 +1,13 @@
+{
+    "id": "batteryPlus",
+    "name": "Battery Plus",
+    "capabilities": ["dankbar-widget", "control-center"],
+    "category": "monitoring",
+    "repo": "https://github.com/arcatva/dms-battery-plus",
+    "author": "arcatva",
+    "description": "Battery panel with phone-style charge history, detailed stats and power profiles",
+    "dependencies": ["upower"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/arcatva/dms-battery-plus/main/screenshots/popout.png"
+}


### PR DESCRIPTION
Adds **Battery Plus** — a battery panel plugin with a phone-style charge history chart (drawn from UPower history via D-Bus, no root needed), detailed stats (health / capacity / energy / voltage / measured average drain / estimated runtime), inline power profile switching and hover readouts on the chart.

Repo: https://github.com/arcatva/dms-battery-plus
Validated locally with `generate.py --validate` and `validate_links.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)