### PR TITLE
Add RAM Monitor, VRAM Monitor and GPU Monitor plugins

### DIFF
--- a/plugins/rollecode-dms-gpu-monitor.json
+++ b/plugins/rollecode-dms-gpu-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "gpuMonitor",
+    "name": "GPU Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rollecode/dms-gpu-monitor",
+    "author": "Rolle Laukkarinen",
+    "description": "NVIDIA GPU load as an animated progress bar in your DankBar, updated every second",
+    "dependencies": ["nvidia-smi"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rollecode/dms-gpu-monitor/main/Screenshot.png"
+}

--- a/plugins/rollecode-dms-ram-monitor.json
+++ b/plugins/rollecode-dms-ram-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "ramMonitor",
+    "name": "RAM Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rollecode/dms-ram-monitor",
+    "author": "Rolle Laukkarinen",
+    "description": "RAM usage as an animated progress bar in your DankBar, updated every second",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rollecode/dms-ram-monitor/main/Screenshot.png"
+}

--- a/plugins/rollecode-dms-vram-monitor.json
+++ b/plugins/rollecode-dms-vram-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "vramMonitor",
+    "name": "VRAM Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rollecode/dms-vram-monitor",
+    "author": "Rolle Laukkarinen",
+    "description": "NVIDIA VRAM usage as an animated progress bar in your DankBar, updated every second",
+    "dependencies": ["nvidia-smi"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rollecode/dms-vram-monitor/main/Screenshot.png"
+}


### PR DESCRIPTION
Three small monitoring widgets for the DankBar, sharing the same visual language: icon, optional customizable label, animated progress bar and percentage, 1 second updates. Fill follows the theme accent and turns orange above 75% and red above 90%.

- RAM Monitor: reads /proc/meminfo (MemTotal - MemAvailable), no dependencies
- VRAM Monitor: nvidia-smi memory.used/memory.total
- GPU Monitor: nvidia-smi utilization.gpu

Both validators pass locally. Screenshot in each repo shows all three side by side.