### PR TITLE
[plugin] OpenTrackerBar: broaden compositor support to any

### DIFF
--- a/plugins/wsmajt-opentrackerbar.json
+++ b/plugins/wsmajt-opentrackerbar.json
@@ -7,7 +7,7 @@
   "author": "smajt",
   "description": "Track AI usage limits via opentracker CLI",
   "dependencies": ["opentracker-cli"],
-  "compositors": ["niri", "hyprland", "sway", "river"],
+  "compositors": ["any"],
   "distro": ["any"],
   "screenshot": "https://raw.githubusercontent.com/wsmajt/OpenTrackerBar/refs/heads/main/Screenshot.png"
 }


### PR DESCRIPTION
As requested by @hthienloc during the review, the plugin configuration was changed and `compositors` is now set to `any`.