### PR TITLE
[plugin] Taskwarrior: set compositor to any

### DIFF
--- a/plugins/cyrylas-taskwarrior.json
+++ b/plugins/cyrylas-taskwarrior.json
@@ -7,7 +7,7 @@
   "author": "Michał Wazgird",
   "capabilities": ["dankbar-widget"],
   "dependencies": ["taskwarrior"],
-  "compositors": ["hyprland", "niri", "sway"],
+  "compositors": ["any"],
   "distro": ["any"],
   "screenshot": "https://raw.githubusercontent.com/cyrylas/dms-taskwarrior/master/screenshots/screenshot-dark.png",
   "requires_dms": ">=1.2.0"


### PR DESCRIPTION
> Taskwarrior integration for DMS: see your pending tasks in the status bar, create new tasks using Taskwarrior syntax, and check them off with a single click

Change compositor to `any` as per @hthienloc request in #371