### PR TITLE
Add Dank Translate AI

### DIFF
--- a/plugins/sakuratoerii-dank-translate-ai.json
+++ b/plugins/sakuratoerii-dank-translate-ai.json
@@ -4,7 +4,6 @@
   "capabilities": [
     "daemon",
     "dankbar-widget",
-    "translation-history"
   ],
   "category": "utilities",
   "repo": "https://github.com/SakuraToErii/dank-translate-ai",

--- a/plugins/sakuratoerii-dank-translate-ai.json
+++ b/plugins/sakuratoerii-dank-translate-ai.json
@@ -1,0 +1,25 @@
+{
+  "id": "dankTranslateAI",
+  "name": "Dank Translate AI",
+  "capabilities": [
+    "daemon",
+    "dankbar-widget",
+    "translation",
+    "translation-history"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/SakuraToErii/dank-translate-ai",
+  "author": "SakuraToErii",
+  "description": "Security-focused, shortcut-driven AI translation with one-shot input reads, local secret screening, streaming, custom OpenAI-compatible APIs, and DankBar history.",
+  "dependencies": [
+    "uv",
+    "wl-clipboard"
+  ],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/SakuraToErii/dank-translate-ai/main/docs/translation-popup.png"
+}

--- a/plugins/sakuratoerii-dank-translate-ai.json
+++ b/plugins/sakuratoerii-dank-translate-ai.json
@@ -21,5 +21,6 @@
   "distro": [
     "any"
   ],
+  "requires_dms": ">=1.5.0",
   "screenshot": "https://raw.githubusercontent.com/SakuraToErii/dank-translate-ai/main/docs/translation-popup.png"
 }

--- a/plugins/sakuratoerii-dank-translate-ai.json
+++ b/plugins/sakuratoerii-dank-translate-ai.json
@@ -4,7 +4,6 @@
   "capabilities": [
     "daemon",
     "dankbar-widget",
-    "translation",
     "translation-history"
   ],
   "category": "utilities",

--- a/plugins/sakuratoerii-dank-translate-ai.json
+++ b/plugins/sakuratoerii-dank-translate-ai.json
@@ -3,7 +3,7 @@
   "name": "Dank Translate AI",
   "capabilities": [
     "daemon",
-    "dankbar-widget",
+    "dankbar-widget"
   ],
   "category": "utilities",
   "repo": "https://github.com/SakuraToErii/dank-translate-ai",


### PR DESCRIPTION
## Plugin

Adds [Dank Translate AI](https://github.com/SakuraToErii/dank-translate-ai), a shortcut-driven AI translation plugin for DMS 1.5+.

It supports any OpenAI-compatible cloud or local model, streams translation into a compact top-center result card, and keeps a persistent newest-first history in DankBar.

## Distinct scope

- [DankTranslate](https://github.com/alcxyz/DankTranslate) provides explicit text translation inside DMS Launcher through `translate-shell`.
- [Glance Translate](https://github.com/ChaoXu1997/glance) provides an editable side-by-side DankBar popout through `translate-shell`.
- Dank Translate AI provides one-shortcut selection/recent-copy translation, custom OpenAI-compatible API and local-model configuration, SSE streaming near the source context, prompt customization, and persistent translation history.

These workflows complement each other: launcher entry, editable dual-pane translation, and security-focused AI translation each serve a separate interaction model.

## Security and privacy

- Clipboard access is strictly one-shot after a shortcut press; the plugin creates zero clipboard subscriptions, polling loops, or resident watcher processes.
- Copied text is eligible for 60 seconds. Older clipboard content is treated as empty.
- Plain-text MIME filtering, file/URI rejection, a 100,000-character limit, and local best-effort credential screening run before clipboard text reaches the configured API.
- API keys travel to the short-lived Python adapter through standard input and stay out of process arguments.
- Repeated shortcuts are coalesced and create no new request until the clipboard entry ID or primary-selection text changes.

## Validation

- 17 unit tests passed.
- `python .github/generate.py --validate` passed.
- Targeted `.github/validate_links.py` passed for the repository, manifest, ID/name match, and screenshot.
- DMS 1.5.0 integration tested on Niri with fresh clipboard input, changed primary selections, and repeated shortcut bursts.

Dependencies: `uv`, `wl-clipboard`  
Compositors: `any`  
Distribution: `any`
