### PR TITLE
feat: add aiQuotas plugin

### DIFF
--- a/plugins/agneswd-ai-quotas.json
+++ b/plugins/agneswd-ai-quotas.json
@@ -7,13 +7,13 @@
   "category": "monitoring",
   "repo": "https://github.com/agneswd/dms-ai-quotas",
   "author": "agneswd",
-  "description": "OpenCode usage quotas and DeepSeek balance in your bar.",
+  "description": "OpenCode Go usage quotas and DeepSeek API balance in your bar.",
   "dependencies": [
     "curl",
     "jq"
   ],
   "compositors": [
-    "niri"
+    "any"
   ],
   "distro": [
     "any"

--- a/plugins/agneswd-ai-quotas.json
+++ b/plugins/agneswd-ai-quotas.json
@@ -18,5 +18,5 @@
   "distro": [
     "any"
   ],
-  "screenshot": "https://i.imgur.com/n2CBZyZ.png"
+  "screenshot": "https://raw.githubusercontent.com/agneswd/dms-ai-quotas/main/assets/screenshot.png"
 }

--- a/plugins/agneswd-ai-quotas.json
+++ b/plugins/agneswd-ai-quotas.json
@@ -1,0 +1,22 @@
+{
+  "id": "aiQuotas",
+  "name": "AI Quotas",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "monitoring",
+  "repo": "https://github.com/agneswd/dms-ai-quotas",
+  "author": "agneswd",
+  "description": "OpenCode usage quotas and DeepSeek balance in your bar.",
+  "dependencies": [
+    "curl",
+    "jq"
+  ],
+  "compositors": [
+    "niri"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://i.imgur.com/n2CBZyZ.png"
+}


### PR DESCRIPTION
Adds **AI Quotas** plugin - displays OpenCode usage quotas and DeepSeek account balance in your DankMaterialShell bar.

Supports:
- OpenCode Rolling/Weekly/Monthly usage % with reset countdowns
- DeepSeek balance (total, granted, topped-up)
- Configurable display mode (remaining or used %)
- Customizable refresh interval
- All credentials configured in DMS settings

Repo: https://github.com/agneswd/dms-ai-quotas