### PR TITLE
Add Dank Calendar Agenda plugin (dankCalendarAgenda)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1680,6 +1680,35 @@ Show ZeroTier network status in the bar and join/leave/route networks from a pop
 
 
 
+#### [Dank Calendar Agenda](https://github.com/arqueon/dms-dankcalendar)
+
+Next-event countdown for dcal with a scrollable agenda popout grouped by day: click an event to open it in DankCalendar, + creates a new one, right click refreshes, middle click toggles the calendar window. Happening-now events in green, past ones dimmed.
+
+
+
+- id: dankCalendarAgenda
+- name: Dank Calendar Agenda
+- author: arqueon
+- compositors: any
+- capabilities: dankbar-widget
+- dependencies: dcal, jq
+- distro: any
+
+
+
+
+
+<details>
+<summary>Screenshot</summary>
+
+![screenshot](https://raw.githubusercontent.com/arqueon/dms-dankcalendar/main/assets/screenshot.png)
+
+</details>
+
+
+
+
+
 #### [Dank Todo](https://github.com/deepu105/dms-dank-todo)
 
 A simple locally-saved TODO list widget for the Dank bar.

--- a/plugins/arqueon-dank-calendar-agenda.json
+++ b/plugins/arqueon-dank-calendar-agenda.json
@@ -1,0 +1,31 @@
+{
+    "id": "dankCalendarAgenda",
+    "name": "Dank Calendar Agenda",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "productivity",
+    "repo": "https://github.com/arqueon/dms-dankcalendar",
+    "description": "Next-event countdown for dcal with a scrollable agenda popout grouped by day: click an event to open it in DankCalendar, + creates a new one, right click refreshes, middle click toggles the calendar window. Happening-now events in green, past ones dimmed.",
+    "version": "1.2.0",
+    "author": "arqueon",
+    "icon": "calendar_today",
+    "type": "widget",
+    "component": "./DankCalendarWidget.qml",
+    "settings": "./DankCalendarSettings.qml",
+    "permissions": [
+        "settings_read",
+        "settings_write"
+    ],
+    "dependencies": [
+        "dcal",
+        "jq"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-dankcalendar/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds **Dank Calendar Agenda** — next-event countdown pill for dcal with a scrollable agenda popout grouped by day: click an event to open its details in DankCalendar, `+` in the header opens day view to create a new event, right click refreshes, middle click toggles the calendar window. Happening-now events highlighted, past ones dimmed.

- Repo: https://github.com/arqueon/dms-dankcalendar (v1.2.0, GPL)
- Fork of leoamaro01/dms-dcal with the dms-dankmail click model
- id `dankCalendarAgenda` — renamed to avoid colliding with the existing `dankCalendar` (alcxyz)
- `generate.py --validate` passes; repo and screenshot URLs return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)