### PR TITLE
feat: add voxtypeActivityOverlay plugin

### DIFF
--- a/plugins/agneswd-voxtype-activity-overlay.json
+++ b/plugins/agneswd-voxtype-activity-overlay.json
@@ -1,0 +1,22 @@
+{
+  "id": "voxtypeActivityOverlay",
+  "name": "VoxType Activity Overlay",
+  "capabilities": [
+    "daemon"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/agneswd/dms-voxtype-activity-overlay",
+  "author": "agneswd",
+  "description": "Live microphone activity overlay while VoxType is recording. Shows a Cava audio visualizer pill and final transcript bubble.",
+  "dependencies": [
+    "voxtype",
+    "cava"
+  ],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/agneswd/dms-voxtype-activity-overlay/main/assets/screenshot-overlay.png"
+}

--- a/plugins/agneswd-voxtype-activity-overlay.json
+++ b/plugins/agneswd-voxtype-activity-overlay.json
@@ -18,5 +18,5 @@
   "distro": [
     "any"
   ],
-  "screenshot": "https://raw.githubusercontent.com/agneswd/dms-voxtype-activity-overlay/main/assets/screenshot-overlay.png"
+  "screenshot": "https://raw.githubusercontent.com/agneswd/dms-voxtype-activity-overlay/main/assets/screenshot-pill.png"
 }


### PR DESCRIPTION
Adds **VoxType Activity Overlay** plugin — a live microphone activity overlay while VoxType is recording.

Features:
- Cava-driven audio visualizer pill with 12 frequency bars
- Optional final transcript bubble after transcribing
- Configurable sensitivity, timing, and opacity
- One-command setup script
- All settings configurable from DMS settings UI

Repo: https://github.com/agneswd/dms-voxtype-activity-overlay