### PR TITLE
[plugin] Add Github Heatmap Plus

### DIFF
--- a/plugins/maxlen727-github-heatmap-plus.json
+++ b/plugins/maxlen727-github-heatmap-plus.json
@@ -1,0 +1,13 @@
+{
+    "id": "githubHeatmapPlus",
+    "name": "GitHub Heatmap Plus",
+    "capabilities": ["dankbar-widget","desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/maxlen727/DMS-GitHub_HeatMap_Plus",
+    "author": "maxlen727",
+    "description": "GitHub contribution heatmap for DankBar and your desktop, with color-coded activity levels and theme-aware styling.",
+    "dependencies": ["dms"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/maxlen727/DMS-GitHub_HeatMap_Plus/refs/heads/main/assets/Overall.png"
+}


### PR DESCRIPTION
GitHub Heatmap Plus is a composite plugin that displays your GitHub contribution heatmap. It includes both a DankBar widget and a desktop widget.

![Overall](https://github.com/maxlen727/DMS-GitHub_HeatMap_Plus/blob/main/assets/Overall.png?raw=true)

Features:

- **DankBar Widget** — A compact pill in your DankBar showing your last 7 days of activity (or just today in compact mode). Click to expand a popout calendar with an interactive detail card showing the exact date and contribution count for any day.
- **Desktop Widget** — A resizable card on your desktop that intelligently adapts its layout: compact 7-day strip when small, full year calendar grid when large.
- **Theme-Aware Colors** — Choose between the classic GitHub green heatmap or follow your DMS accent color for a seamless look that matches your desktop theme.
- **Granular Settings** — Fine-tune every aspect: square size, spacing, background opacity, refresh rate, compact mode, and more.