### PR TITLE
[plugin] Add Recent Files

### DIFF
--- a/plugins/gouwazi-recent-files.json
+++ b/plugins/gouwazi-recent-files.json
@@ -4,7 +4,7 @@
     "capabilities": ["launcher"],
     "category": "utilities",
     "repo": "https://github.com/gouwazi/dms-recent-files",
-    "author": "gouwazi",
+    "author": "Xianggang Wang",
     "description": "Search recently opened XDG files directly from the DMS launcher",
     "dependencies": [],
     "compositors": ["any"],

--- a/plugins/gouwazi-recent-files.json
+++ b/plugins/gouwazi-recent-files.json
@@ -1,0 +1,14 @@
+{
+    "id": "recentFiles",
+    "name": "Recent Files",
+    "capabilities": ["launcher"],
+    "category": "utilities",
+    "repo": "https://github.com/gouwazi/dms-recent-files",
+    "author": "gouwazi",
+    "description": "Search recently opened XDG files directly from the DMS launcher",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/gouwazi/dms-recent-files/refs/heads/master/screenshot.png",
+    "requires_dms": ">=1.5.0"
+}


### PR DESCRIPTION
Adds Recent Files, a launcher plugin that surfaces XDG recent files in DMS unified search.

- No external runtime dependencies
- Works with any compositor and distribution
- Includes a screenshot and requires DMS 1.5.0 or newer

Validation:

- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/gouwazi-recent-files.json python3 .github/validate_links.py`