### PR TITLE
Add Intel GPU Monitor plugin

### DIFF
--- a/plugins/rdannenbring-intel-gpu-monitor.json
+++ b/plugins/rdannenbring-intel-gpu-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "intelGpuMonitor",
+    "name": "Intel GPU Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rdannenbring/dms-intel-gpu-plugin",
+    "author": "rdannenbring",
+    "description": "Monitor Intel GPU usage, VRAM and temperature in the DankBar with configurable charts and a per-process detail view — reads kernel DRM fdinfo and sysfs directly, no root or extra tools required.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rdannenbring/dms-intel-gpu-plugin/main/Screenshot.png"
+}


### PR DESCRIPTION
Adds **Intel GPU Monitor** — a DankBar widget for Intel GPUs (integrated or discrete Arc).

- GPU usage, VRAM, and temperature in the bar with configurable charts (horizontal/vertical bar, gauge, donut, pie, thermometer)
- Detail view with a per-engine breakdown and a per-process table (GPU %, VRAM MB, VRAM %, PID)
- Reads kernel DRM `fdinfo` + sysfs directly — **no dependencies, no root, no `CAP_PERFMON`**, and it doesn't wake the GPU

Repo: https://github.com/rdannenbring/dms-intel-gpu-plugin

Validated locally with `.github/generate.py --validate` and `CHANGED_PLUGINS=... .github/validate_links.py` — both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)