### PR TITLE
[plugin] Add screen capture and recorder plugins

### DIFF
--- a/plugins/crowforkotlin-screen-capture.json
+++ b/plugins/crowforkotlin-screen-capture.json
@@ -1,0 +1,19 @@
+{
+  "id": "screenCapture",
+  "name": "Screen Capture",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/crowforkotlin/dms-screen-capture",
+  "author": "crowforkotlin",
+  "description": "Take screenshots using Niri's built-in command with area, full screen and active window modes",
+  "dependencies": [],
+  "compositors": [
+    "niri"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/crowforkotlin/dms-screen-capture/main/Screenshot.png"
+}

--- a/plugins/crowforkotlin-screen-recorder.json
+++ b/plugins/crowforkotlin-screen-recorder.json
@@ -1,0 +1,24 @@
+{
+  "id": "screenRecorder",
+  "name": "Screen Recorder",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/crowforkotlin/dms-screen-recorder",
+  "author": "crowforkotlin",
+  "description": "Record screen or selected area using wf-recorder with configurable codec, framerate, quality, resolution, format and save path",
+  "dependencies": [
+    "wf-recorder",
+    "zenity"
+  ],
+  "compositors": [
+    "niri",
+    "hyprland",
+    "sway"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/crowforkotlin/dms-screen-recorder/main/Screenshot.png"
+}


### PR DESCRIPTION
- Register screen capture utility plugin with Niri compositor support
- Register screen recorder utility plugin with wf-recorder and zenity dependencies
- https://github.com/crowforkotlin/dms-screen-capture
- https://github.com/crowforkotlin/dms-screen-recorder
This providing screen capturing capabilities for Niri and recording features for Niri, Hyprland, and Sway.
<img width="288" height="282" alt="Screenshot" src="https://github.com/user-attachments/assets/153d975f-486e-4507-b44a-29a699c17553" />
<img width="287" height="237" alt="Screenshot" src="https://github.com/user-attachments/assets/70eda319-14ae-45ad-b12d-613f565eb60e" />
<img width="288" height="473" alt="Screenshot_setting" src="https://github.com/user-attachments/assets/9d801183-c922-4d5c-95c9-978603c1d494" />
