### PR TITLE
feat: add registry entry for Steam Big Picture dankbar widget

### DIFF
--- a/plugins/jessvolet-dankconsolemodewithsteam.json
+++ b/plugins/jessvolet-dankconsolemodewithsteam.json
@@ -13,7 +13,7 @@
         "gamescope"
     ],
     "compositors": [
-        "niri"
+        "any"
     ],
     "distro": [
         "any"

--- a/plugins/jessvolet-dankconsolemodewithsteam.json
+++ b/plugins/jessvolet-dankconsolemodewithsteam.json
@@ -1,0 +1,22 @@
+{
+    "id": "dankConsoleSteam",
+    "name": "Steam Big Picture",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/JessVolet/DankConsoleModeWithSteam",
+    "author": "JessVolet",
+    "description": "A simple widget to start steam in big picture mode with custom commands.",
+    "dependencies": [
+        "steam",
+        "gamescope"
+    ],
+    "compositors": [
+        "niri"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/JessVolet/DankConsoleModeWithSteam/main/screenshot.png"
+}


### PR DESCRIPTION
This plugin provides a simple bar/control center widget to launch Steam in Big Picture mode with support for native/Flatpak execution, Gamescope parameters, automation scripts (via command hooks), and custom audio device routing.