### PR TITLE
[plugin] Add Cardwire Manager

### DIFF
--- a/plugins/jankelemen-cardwire-manager.json
+++ b/plugins/jankelemen-cardwire-manager.json
@@ -1,0 +1,13 @@
+{
+    "id": "cardwireManager",
+    "name": "Cardwire Manager",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/jankelemen/cardwire-manager",
+    "author": "Jan Kelemen",
+    "description": "DankBar widget for selecting Cardwire GPU modes and showing the currently active mode.",
+    "dependencies": ["cardwire"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/jankelemen/cardwire-manager/master/assets/screenshot.png"
+}


### PR DESCRIPTION
DankBar widget for selecting Cardwire GPU modes and displaying the currently active mode.
It periodically polls cardwire get to keep the displayed mode up to date. Modes can be switched from the popout, and the polling interval can be configured or periodic polling disabled.