### PR TITLE
Add DMS Nothing X to registry

### DIFF
--- a/plugins/bestello-dms-nothingx.json
+++ b/plugins/bestello-dms-nothingx.json
@@ -1,0 +1,13 @@
+{
+    "id": "dmsNothingX",
+    "name": "DMS Nothing X",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Bestello/dms-nothingx",
+    "author": "Bestello",
+    "description": "Control center for Nothing and CMF audio devices",
+    "dependencies": ["python3"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Bestello/dms-nothingx/main/docs/screenshot.png"
+}


### PR DESCRIPTION
Adding my new plugin to control ANC and view battery for CMF and Nothing devices. 