### PR TITLE
feat: add Sit/Stand Reminder

### DIFF
--- a/plugins/knappancash-sit-stand-reminder.json
+++ b/plugins/knappancash-sit-stand-reminder.json
@@ -1,0 +1,14 @@
+{
+  "id": "sitStandReminder",
+  "name": "Sit/Stand Reminder",
+  "capabilities": ["daemon", "dankbar-widget", "control-center"],
+  "category": "productivity",
+  "repo": "https://github.com/knappancash/SitStandReminder",
+  "author": "Justus",
+  "description": "Reminds you to alternate between sitting and standing with configurable, idle-aware timers.",
+  "dependencies": ["notify-send"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "requires_dms": ">=1.5.0",
+  "screenshot": "https://raw.githubusercontent.com/knappancash/SitStandReminder/main/sit-stand-reminder-preview.png"
+}


### PR DESCRIPTION
## Summary

Add Sit/Stand Reminder, a DMS 1.5+ productivity plugin with configurable, idle-aware posture timers.

The canonical repository is on [Codeberg](https://codeberg.org/knappancash/SitStandReminder); the linked GitHub repository is its public mirror for registry compatibility.

## Validation

- `python3 .github/generate.py --validate`
- `python3 .github/validate_links.py`
- Plugin manifest validated against the current DMS `plugin-schema.json`