### PR TITLE
[plugin] Add Wayfire Workspace

### DIFF
--- a/plugins/joyanhui-wayfire-workspace.json
+++ b/plugins/joyanhui-wayfire-workspace.json
@@ -1,0 +1,13 @@
+{
+    "id": "wayfireWorkspace",
+    "name": "Wayfire Workspace",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/joyanhui/dms-ext-wayfire-workspace",
+    "author": "joyanhui",
+    "description": "Display Wayfire workspace switcher in the bar with active/occupied indicators and click-to-switch",
+    "dependencies": ["python3"],
+    "compositors": ["wayfire"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/joyanhui/dms-ext-wayfire-workspace/raw/main/screenshot.png"
+}


### PR DESCRIPTION
## Summary

Adds **wayfireWorkspace** — a DMS bar widget that displays Wayfire workspace information via IPC.

### Details

- **ID:** wayfireWorkspace
- **Name:** Wayfire Workspace
- **Repository:** https://github.com/joyanhui/dms-ext-wayfire-workspace
- **Category:** utilities
- **Capabilities:** dankbar-widget
- **Compositors:** wayfire
- **Dependencies:** python3

The plugin consists of:
- A Python daemon that connects to Wayfire IPC socket and tracks workspace/view state
- A QML PluginComponent that displays workspace buttons in the DMS bar
- Settings panel for color customization

See the [repository README](https://github.com/joyanhui/dms-ext-wayfire-workspace) for full documentation.