### PR TITLE
[plugin] Add CPU Monitor and Disk Monitor

### DIFF
--- a/plugins/rollecode-dms-cpu-monitor.json
+++ b/plugins/rollecode-dms-cpu-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "cpuMonitor",
+    "name": "CPU Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rollecode/dms-cpu-monitor",
+    "author": "Rolle Laukkarinen",
+    "description": "CPU usage as an animated progress bar in your DankBar, updated every second",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rollecode/dms-cpu-monitor/main/Screenshot.png"
+}

--- a/plugins/rollecode-dms-disk-monitor.json
+++ b/plugins/rollecode-dms-disk-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "diskMonitor",
+    "name": "Disk Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rollecode/dms-disk-monitor",
+    "author": "Rolle Laukkarinen",
+    "description": "Disk usage as an animated progress bar in your DankBar, refreshed every 30 seconds",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rollecode/dms-disk-monitor/main/Screenshot.png"
+}


### PR DESCRIPTION
Two more monitoring widgets in the same family as the RAM, VRAM and GPU monitors: icon, optional customizable label, animated progress bar and percentage. Fill follows the theme accent and turns orange above 75% and red above 90%.

- CPU Monitor: /proc/stat delta every second, popout with Idle and CPU temperature pinned plus per-process CPU sampled over half a second like top, kill icons
- Disk Monitor: 30 second polls, root disk or all disks combined via a setting, popout lists each filesystem with used space and total size, external mounts hidden behind a toggle

Schema validator passes locally; both screenshot links return 200.