### PR TITLE
plugins: update Last.fm Scrobbler to 1.4.0

### DIFF
--- a/plugins/arqueon-lastfm-scrobbler.json
+++ b/plugins/arqueon-lastfm-scrobbler.json
@@ -1,8 +1,9 @@
 {
     "id": "lastfmScrobbler",
     "name": "DMS Last.fm Scrobbler",
-    "version": "1.1.0",
+    "version": "1.4.0",
     "capabilities": [
+        "daemon",
         "dankbar-widget",
         "control-center",
         "ipc"
@@ -10,7 +11,7 @@
     "category": "media",
     "repo": "https://github.com/arqueon/dms-scrobbler",
     "author": "arqueon",
-    "description": "Scrobble MPRIS music to Last.fm, love/unlove tracks from the bar or via IPC, with media controls, album art, scrobble progress, an offline retry queue, and a live audio visualizer.",
+    "description": "Last.fm companion for the native DMS media player: scrobbling, love/unlove actions, profile links, scrobble progress, and an offline retry queue.",
     "dependencies": [
         "python3"
     ],


### PR DESCRIPTION
## Summary

- update DMS Last.fm Scrobbler from 1.1.0 to 1.4.0;
- declare its daemon capability;
- describe it as a companion to the native DMS media player instead of a replacement media controller.

The existing screenshot URL now serves a real, tightly cropped view of the current 1.4.0 popout from `main`.

## Validation

- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/arqueon-lastfm-scrobbler.json python3 .github/validate_links.py`
- `jq empty plugins/arqueon-lastfm-scrobbler.json`
- `git diff --check`
