### PR TITLE
[plugin] Add Nothing Clock Widget

### DIFF
--- a/plugins/samgrande-nothing-clock.json
+++ b/plugins/samgrande-nothing-clock.json
@@ -1,0 +1,14 @@
+{
+    "id": "nothingClock",
+    "name": "Nothing Clock",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/samgrande/Dank-Nothing-Clock",
+    "path": "nothingclock",
+    "author": "Sayan",
+    "description": "Nothing OS-inspired desktop clock with 6 styles: digital, split, analog, analog classic, digital cards, and orbit.",
+    "dependencies": [],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/samgrande/Dank-Nothing-Clock/main/assets/screenshots/preview.png"
+}

--- a/plugins/samgrande-nothing-clock.json
+++ b/plugins/samgrande-nothing-clock.json
@@ -8,7 +8,7 @@
     "author": "Sayan",
     "description": "Nothing OS-inspired desktop clock with 6 styles: digital, split, analog, analog classic, digital cards, and orbit.",
     "dependencies": [],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/samgrande/Dank-Nothing-Clock/main/assets/screenshots/preview.png"
 }


### PR DESCRIPTION
Adds Nothing Clock, a Nothing OS–inspired desktop clock widget with 6 styles
(Digital, Split, Analog, Analog Classic, Stacks, Orbit), configurable accent
color, 12/24-hour format, and adjustable background opacity.

Repo: https://github.com/samgrande/Dank-Nothing-Clock