### PR TITLE
Add dms-ntfy persistent inbox plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2144,6 +2144,35 @@ Your Wallabag read-it-later queue in the DankBar: unread badge, entry list with 
 
 
 
+#### [ntfy](https://github.com/arqueon/dms-ntfy)
+
+A persistent ntfy review inbox for the DankBar with All and per-topic views, unread state, local search, links, attachments, and explicit local dismissal. Supports ntfy.sh and any self-hosted instance.
+
+<strong>requires DMS version</strong>: <em>>=1.5.0</em>
+
+- id: ntfy
+- name: ntfy
+- author: arqueon
+- compositors: any
+- capabilities: daemon, dankbar-widget, ipc
+- dependencies: curl, secret-tool, base64
+- distro: any
+
+
+
+
+
+<details>
+<summary>Screenshot</summary>
+
+![screenshot](https://raw.githubusercontent.com/arqueon/dms-ntfy/main/assets/screenshot.png)
+
+</details>
+
+
+
+
+
 ---
 
 

--- a/README.md
+++ b/README.md
@@ -2144,14 +2144,14 @@ Your Wallabag read-it-later queue in the DankBar: unread badge, entry list with 
 
 
 
-#### [ntfy](https://github.com/arqueon/dms-ntfy)
+#### [dms-ntfy](https://github.com/arqueon/dms-ntfy)
 
 A persistent ntfy review inbox for the DankBar with All and per-topic views, unread state, local search, links, attachments, and explicit local dismissal. Supports ntfy.sh and any self-hosted instance.
 
 <strong>requires DMS version</strong>: <em>>=1.5.0</em>
 
 - id: ntfy
-- name: ntfy
+- name: dms-ntfy
 - author: arqueon
 - compositors: any
 - capabilities: daemon, dankbar-widget, ipc

--- a/plugins/arqueon-ntfy.json
+++ b/plugins/arqueon-ntfy.json
@@ -1,6 +1,6 @@
 {
     "id": "ntfy",
-    "name": "ntfy",
+    "name": "dms-ntfy",
     "capabilities": [
         "daemon",
         "dankbar-widget",

--- a/plugins/arqueon-ntfy.json
+++ b/plugins/arqueon-ntfy.json
@@ -1,0 +1,41 @@
+{
+    "id": "ntfy",
+    "name": "ntfy",
+    "capabilities": [
+        "daemon",
+        "dankbar-widget",
+        "ipc"
+    ],
+    "category": "productivity",
+    "repo": "https://github.com/arqueon/dms-ntfy",
+    "description": "A persistent ntfy review inbox for the DankBar with All and per-topic views, unread state, local search, links, attachments, and explicit local dismissal. Supports ntfy.sh and any self-hosted instance.",
+    "version": "0.1.0",
+    "author": "arqueon",
+    "icon": "notifications",
+    "type": "composite",
+    "components": {
+        "daemon": "./NtfyDaemon.qml",
+        "widget": "./NtfyWidget.qml"
+    },
+    "settings": "./Settings.qml",
+    "startupCheck": "./StartupCheck.qml",
+    "permissions": [
+        "settings_read",
+        "settings_write",
+        "network",
+        "process"
+    ],
+    "requires_dms": ">=1.5.0",
+    "dependencies": [
+        "curl",
+        "secret-tool",
+        "base64"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-ntfy/main/assets/screenshot.png"
+}


### PR DESCRIPTION
## What changed

- adds the `dms-ntfy` composite plugin (ID `ntfy`) to the productivity category
- includes the generated README entry and a public demo-data screenshot
- declares daemon, DankBar widget, and IPC capabilities for DMS 1.5+

## Why

ntfy notifications can outlive desktop popups and often need to be reviewed by
topic. This plugin provides a persistent local inbox with an All view,
per-topic sections, read state, search, links, attachments, and explicit
dismissal while avoiding duplicate DMS desktop notifications.

It supports ntfy.sh and arbitrary self-hosted instances with public,
bearer-token, or HTTP Basic authentication.

## Validation

- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/arqueon-ntfy.json python3 .github/validate_links.py`
- repository `plugin.json`, screenshot, ID, and name links validated successfully
- plugin loaded as `composite` in DMS and was exercised with synthetic data plus
  a live self-hosted ntfy instance
