### PR TITLE
Add I/O Monitor

### DIFF
--- a/plugins/rollecode-dms-io-monitor.json
+++ b/plugins/rollecode-dms-io-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "ioMonitor",
+    "name": "I/O Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rollecode/dms-io-monitor",
+    "author": "Rolle Laukkarinen",
+    "description": "Live disk read and write throughput as an animated progress bar in your DankBar",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rollecode/dms-io-monitor/main/Screenshot.png"
+}


### PR DESCRIPTION
Disk throughput widget in the same family as the RAM, VRAM, GPU, CPU and Disk monitors: icon, optional customizable label, animated progress bar and percentage, sized by the bar's own font scale.

Reads and writes count together against a configurable full-scale throughput. The popout pins read, write and the busiest disk, then lists each disk and per-process I/O with kill icons. Per-process figures come from /proc/<pid>/io, so they are real block-device traffic rather than page-cache hits.

Falls back to summing per-process I/O on systems where a udev rule sets queue/iostats to 0 and leaves /proc/diskstats frozen, and marks those rows so the source is never a guess.

Schema validator passes locally; the screenshot link returns 200.