### PR TITLE
[plugin] Add Spotify Matugen and SVGL Search

### DIFF
--- a/plugins/grant07-spotify-matugen.json
+++ b/plugins/grant07-spotify-matugen.json
@@ -1,0 +1,13 @@
+{
+  "id": "spotifyMatugen",
+  "name": "Spotify Matugen",
+  "capabilities": ["daemon"],
+  "category": "appearance",
+  "repo": "https://github.com/Grant07/dms-spotify-matugen",
+  "author": "Grant Mosha",
+  "description": "Lock DMS dynamic colors to Spotify album art while music is playing",
+  "dependencies": ["spotify", "matugen"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/Grant07/dms-spotify-matugen/main/assets/screenshot.png"
+}

--- a/plugins/grant07-svgl-search.json
+++ b/plugins/grant07-svgl-search.json
@@ -1,0 +1,13 @@
+{
+  "id": "svglSearch",
+  "name": "SVGL Search",
+  "capabilities": ["launcher"],
+  "category": "utilities",
+  "repo": "https://github.com/Grant07/dms-svgl-search",
+  "author": "Grant Mosha",
+  "description": "Search and copy SVGL brand logos directly from the DMS launcher",
+  "dependencies": ["wl-copy"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/Grant07/dms-svgl-search/main/assets/screenshot.png"
+}


### PR DESCRIPTION
## Plugins

- **Spotify Matugen** — locks DMS dynamic colors to Spotify album art while playback is active.
- **SVGL Search** — searches and copies SVGL brand assets from the DMS launcher.

Both plugins are documented, MIT-licensed, and include live DMS screenshots.

## Validation

- `python3 .github/generate.py --validate`
- `python3 .github/validate_links.py` for both changed entries
- `python3 .github/validate_themes.py`
- QML/JSON validation in both source repositories