### PR TITLE
shellyUpdater: require Shelly v3, add control-center-widget capability

### DIFF
--- a/plugins/rdannenbring-shelly-updater.json
+++ b/plugins/rdannenbring-shelly-updater.json
@@ -1,7 +1,7 @@
 {
   "id": "shellyUpdater",
   "name": "Shelly Updater",
-  "capabilities": ["dankbar-widget", "control-center-widget"],
+  "capabilities": ["dankbar-widget", "control-center"],
   "category": "system",
   "repo": "https://github.com/rdannenbring/dms-shelly-updater",
   "screenshot": "https://raw.githubusercontent.com/rdannenbring/dms-shelly-updater/main/preview/updates.png",

--- a/plugins/rdannenbring-shelly-updater.json
+++ b/plugins/rdannenbring-shelly-updater.json
@@ -1,13 +1,13 @@
 {
   "id": "shellyUpdater",
   "name": "Shelly Updater",
-  "capabilities": ["dankbar-widget"],
+  "capabilities": ["dankbar-widget", "control-center-widget"],
   "category": "system",
   "repo": "https://github.com/rdannenbring/dms-shelly-updater",
   "screenshot": "https://raw.githubusercontent.com/rdannenbring/dms-shelly-updater/main/preview/updates.png",
   "author": "rdannenbring",
-  "description": "Comprehensive system update widget backed by the Shelly (ALPM) CLI — pacman, AUR, Flatpak and AppImage in one DankBar pill with a detailed updates view and an action menu.",
-  "dependencies": ["shelly"],
+  "description": "Comprehensive system update widget backed by the Shelly (ALPM) CLI — pacman, AUR, Flatpak and AppImage in one DankBar pill with a detailed updates view, action menu, and control-center panel. Requires Shelly v3+.",
+  "dependencies": ["shelly>=3"],
   "compositors": ["any"],
   "distro": ["arch"]
 }


### PR DESCRIPTION
Updates the existing `shellyUpdater` entry for the plugin's v2.0.0 release:

- **`dependencies`**: `shelly` → `shelly>=3`. Shelly 3.0 reworked its CLI grammar; plugin versions before 2.0.0 break on Shelly v3, and v2.0.0 requires it.
- **`capabilities`**: add `control-center-widget` — the plugin now also provides a DankMaterialShell control-center widget (matches its `plugin.json`).
- **`description`**: mention the control-center panel and note the Shelly v3 requirement.

No repo/id/name changes. `python3 .github/generate.py --validate` → "Validation successful!".