### PR TITLE
[plugin] Add Pokedash Widget

### DIFF
--- a/plugins/samgrande-pokedash.json
+++ b/plugins/samgrande-pokedash.json
@@ -1,0 +1,14 @@
+{
+    "id": "pokeDash",
+    "name": "PokeDash",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/samgrande/PokeDash",
+    "path": "pokedash",
+    "author": "Sayan",
+    "description": "Pick your favorite pokemon, plop it on your desktop, and watch it idle menacingly (or adorably) while you actually get work done.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/samgrande/PokeDash/main/assets/screenshots/preview.png"
+}


### PR DESCRIPTION
Adds PokeDash, a new DankMaterialShell desktop widget that displays a single idle 8-bit Pokémon sprite on the desktop.

Includes a Pokemon picker in the plugin settings, adjustable sprite scale, and three background styles (transparent / DMS theme / glass).