### PR TITLE
[plugin] Add Cursor Highlight

### DIFF
--- a/plugins/reyarlena-cursor-highlight.json
+++ b/plugins/reyarlena-cursor-highlight.json
@@ -1,0 +1,13 @@
+{
+    "id": "cursorHighlight",
+    "name": "Cursor Highlight",
+    "capabilities": ["daemon"],
+    "category": "utilities",
+    "repo": "https://github.com/ReyArlena/dms-cursor-highlight",
+    "author": "ReyArlena",
+    "description": "Cursor highlight for presentations, screen sharing or gaming. Rainbow mode, per-style settings, IPC keybind support.",
+    "dependencies": ["python3"],
+    "compositors": ["hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/ReyArlena/dms-cursor-highlight/main/assets/screenshot.png"
+}


### PR DESCRIPTION
## Add Cursor Highlight

Adds `plugins/reyarlena-cursor-highlight.json` for [Cursor Highlight](https://github.com/ReyArlena/dms-cursor-highlight), a daemon plugin that draws a click-through highlight (ring, dot, or arrow) at the cursor - useful for presentations, screen sharing, and gaming. The highlight is a normal Wayland surface, so it's captured by screencopy even when the hardware cursor is not.

**Features**
- Three styles (ring / dot / arrow) with per-style size, offset, color, and rainbow settings
- Rainbow mode that cycles the hue of the selected color
- Toggle via IPC (`dms ipc call cursorHighlight toggle`) for keybinds, plus a settings-panel toggle
- Startup check: refuses to load with a clear error if Hyprland or python3 is missing

![Screenshot](https://raw.githubusercontent.com/ReyArlena/dms-cursor-highlight/main/assets/screenshot_full.png)