### PR TITLE
Add VoxType OSD plugin

### DIFF
--- a/plugins/irisblur17-dms-voxtype-osd.json
+++ b/plugins/irisblur17-dms-voxtype-osd.json
@@ -1,0 +1,14 @@
+{
+    "id": "voxTypeOsd",
+    "name": "VoxType OSD",
+    "capabilities": ["monitoring"],
+    "category": "monitoring",
+    "repo": "https://github.com/irisblur17/dms-voxtype-osd",
+    "author": "Iris Blur",
+    "description": "VoxType recording and transcription waveform OSD",
+    "dependencies": ["voxtype", "voxtype-audio-bridge"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/irisblur17/dms-voxtype-osd/main/screenshot.png",
+    "requires_dms": ">=1.5.0"
+}


### PR DESCRIPTION
## Summary

- Add VoxType OSD, a DMS-themed recording and transcription waveform overlay for VoxType
- Include configurable waveform behavior, OSD sizing, visibility, and cancellation
- Declare VoxType dependencies and DMS 1.5.0 compatibility

## Validation

- Registry metadata validation passed
- Repository, screenshot, plugin ID, and plugin name link validation passed