### PR TITLE
[plugin] Add SPlayer Lyrics (Desktop)

### DIFF
--- a/plugins/brkp-splayerdesktoplyrics.json
+++ b/plugins/brkp-splayerdesktoplyrics.json
@@ -1,0 +1,13 @@
+{
+    "id": "splayerDesktopLyrics",
+    "name": "SPlayer Lyrics (Desktop)",
+    "capabilities": ["desktop-widget"],
+    "category": "media",
+    "repo": "https://github.com/brkp/DMS_splayerLyrics",
+    "author": "brkpt",
+    "description": "Desktop lyrics widget for SPlayer, fetches lyrics from SPlayer's local Netease API",
+    "dependencies": ["dms"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/brkp/DMS_splayerLyrics/main/screenshot.png"
+}

--- a/plugins/brkp-splayerdesktoplyrics.json
+++ b/plugins/brkp-splayerdesktoplyrics.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/brkp/DMS_splayerLyrics",
     "author": "brkpt",
     "description": "Desktop lyrics widget for SPlayer, fetches lyrics from SPlayer's local Netease API",
-    "dependencies": ["dms"],
+    "dependencies": [],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/brkp/DMS_splayerLyrics/main/screenshot.png"


### PR DESCRIPTION
Adds the SPlayer Lyrics (Desktop) plugin to the registry.

- **id**: splayerDesktopLyrics
- **name**: SPlayer Lyrics (Desktop)
- **capabilities**: desktop-widget
- **category**: media
- **repo**: https://github.com/brkp/DMS_splayerLyrics
- **description**: Desktop lyrics widget for SPlayer, fetches lyrics from SPlayer's local Netease API

Local validation passed: `generate.py --validate` and `validate_links.py` both successful.