### PR TITLE
[plugin] Add Retro Viseur

### DIFF
--- a/plugins/elopin42-retro-viseur.json
+++ b/plugins/elopin42-retro-viseur.json
@@ -7,7 +7,7 @@
     "author": "elopin42",
     "description": "Rear-view mirror: click the bar icon to open a small popup with your live webcam feed",
     "dependencies": ["qt6-multimedia-ffmpeg"],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/elopin42/dank-retro-viseur/main/screenshot.png"
 }

--- a/plugins/elopin42-retro-viseur.json
+++ b/plugins/elopin42-retro-viseur.json
@@ -1,0 +1,13 @@
+{
+    "id": "retroViseur",
+    "name": "Retro Viseur",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/elopin42/dank-retro-viseur",
+    "author": "elopin42",
+    "description": "Rear-view mirror: click the bar icon to open a small popup with your live webcam feed",
+    "dependencies": ["qt6-multimedia-ffmpeg"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/elopin42/dank-retro-viseur/main/screenshot.png"
+}


### PR DESCRIPTION
Adds **Retro Viseur** — a rear-view mirror widget for the DankBar: click the camera icon to open a small popup showing your live webcam feed.

- Repo: https://github.com/elopin42/dank-retro-viseur (tagged v1.0.0)
- Features: 16:9 camera popup, mirror flip, double-click zoom, popup resize toggle, multi-camera switching
- Camera is only active while the popup is open
- `generate.py --validate` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)