### PR TITLE
[plugin] Add VoxType Recording Overlay

### DIFF
--- a/plugins/rdannenbring-voxtype-overlay.json
+++ b/plugins/rdannenbring-voxtype-overlay.json
@@ -1,0 +1,13 @@
+{
+  "id": "voxtypeOverlay",
+  "name": "VoxType Recording Overlay",
+  "capabilities": ["daemon", "dankbar-widget", "control-center", "ipc"],
+  "category": "utilities",
+  "repo": "https://github.com/rdannenbring/voxtype-dms-overlay",
+  "screenshot": "https://raw.githubusercontent.com/rdannenbring/voxtype-dms-overlay/main/assets/overlay.png",
+  "author": "rdannenbring",
+  "description": "VoxType for DMS: a recording overlay (dim + active-window cutout + pulsing mic) and a bar/tray control widget — start/stop the daemon, switch output mode, pick your mic, switch engine, and run meetings from your DMS bar.",
+  "dependencies": ["voxtype"],
+  "compositors": ["any"],
+  "distro": ["any"]
+}


### PR DESCRIPTION
Adds **VoxType Recording Overlay** to the registry — thanks for the plugin system, it's been a pleasure to build on.

A composite DMS plugin for [VoxType](https://github.com/peteonrails/voxtype), in two independently-toggleable halves:

- **Recording overlay** — dims every monitor, cuts out the active window (Hyprland) with a themed border, and shows a pulsing mic while dictating.
- **Bar/tray control widget** — start / stop / restart the daemon, switch output mode, pick your microphone, switch engine, and run meetings, all from the DMS bar. Replaces the external SNI tray app for DMS users.

The widget + dim work on any wlroots compositor; only the active-window cutout is Hyprland-specific.

- Repo: https://github.com/rdannenbring/voxtype-dms-overlay
- Screenshots are in the repo README.
- Validated locally with `python3 .github/generate.py --validate` ✓