### PR TITLE
[plugin] Add Persian Calendar Pro

### DIFF
--- a/plugins/rassoulshah-persian-calendar.json
+++ b/plugins/rassoulshah-persian-calendar.json
@@ -1,0 +1,13 @@
+{
+  "id": "persianCalendar",
+  "name": "Persian Calendar Pro",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/rassoulshah/dms-persian-calendar",
+  "author": "Rassoul Shahsanaii",
+  "description": "A bilingual Persian Jalali calendar with holidays, occasions, custom events, configurable date formats, and a full month popup.",
+  "dependencies": [],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/rassoulshah/dms-persian-calendar/main/screenshots/popup.png"
+}


### PR DESCRIPTION
## Persian Calendar Pro

Adds a bilingual Persian/Jalali calendar widget for Dank Material Shell.

Features:

- Full monthly Jalali calendar popup
- Persian and Latin transliterated dates
- Official Iranian holidays for 1405
- Important national and cultural occasions
- Custom personal events
- Configurable date format and font
- Persian digits
- Support for horizontal and vertical DankBar layouts

Tested on CachyOS with MangoWC and DMS.