### PR TITLE
[plugin] Add LaTeX to SVG

### DIFF
--- a/plugins/kinnariyamamatanha-latex2svg.json
+++ b/plugins/kinnariyamamatanha-latex2svg.json
@@ -1,0 +1,14 @@
+{
+  "id": "latex2svg",
+  "name": "LaTeX to SVG",
+  "capabilities": ["dankbar-widget", "latex-rendering", "clipboard"],
+  "category": "utilities",
+  "repo": "https://github.com/KinnariyaMamaTanha/latex2svg",
+  "author": "KinnariyaMamaTanha",
+  "description": "Convert LaTeX formulas to portable SVG from Dank Bar, with preview, configurable saving, and clipboard copy.",
+  "dependencies": ["python3", "latex", "dvisvgm"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/KinnariyaMamaTanha/latex2svg/main/assets/screenshot.png",
+  "requires_dms": ">=1.5.0"
+}

--- a/plugins/kinnariyamamatanha-latex2svg.json
+++ b/plugins/kinnariyamamatanha-latex2svg.json
@@ -1,7 +1,7 @@
 {
   "id": "latex2svg",
   "name": "LaTeX to SVG",
-  "capabilities": ["dankbar-widget", "latex-rendering", "clipboard"],
+  "capabilities": ["dankbar-widget"],
   "category": "utilities",
   "repo": "https://github.com/KinnariyaMamaTanha/latex2svg",
   "author": "KinnariyaMamaTanha",

--- a/plugins/kinnariyamamatanha-latex2svg.json
+++ b/plugins/kinnariyamamatanha-latex2svg.json
@@ -5,7 +5,7 @@
   "category": "utilities",
   "repo": "https://github.com/KinnariyaMamaTanha/latex2svg",
   "author": "KinnariyaMamaTanha",
-  "description": "Convert LaTeX formulas to portable SVG from Dank Bar, with preview, configurable saving, and clipboard copy.",
+  "description": "Convert LaTeX formulas to portable SVG from Dank Bar, with a sharp preview, configurable saving, and image clipboard copy.",
   "dependencies": ["python3", "latex", "dvisvgm"],
   "compositors": ["any"],
   "distro": ["any"],


### PR DESCRIPTION
Adds LaTeX to SVG, a Dank Bar plugin that converts local LaTeX formulas to portable SVG with preview, configurable saving, and clipboard copy. The plugin registry generator and link validator both pass locally.