### PR TITLE
[plugin] Add Sysmon

### DIFF
--- a/plugins/rtabulov-sysmon.json
+++ b/plugins/rtabulov-sysmon.json
@@ -1,14 +1,22 @@
 {
     "id": "sysmon",
     "name": "Sysmon",
-    "capabilities": ["dankbar-widget"],
+    "capabilities": [
+        "dankbar-widget"
+    ],
     "category": "monitoring",
     "repo": "https://github.com/rtabulov/dms-sysmon",
     "path": "plugin",
     "author": "rassul",
     "description": "Compact DankBar Pill of system resource Items with a graph Popout",
-    "dependencies": ["dgop"],
-    "compositors": ["any"],
-    "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/rtabulov/dms-sysmon/main/plugin/assets/pill.png"
+    "dependencies": [
+        "dgop"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/rtabulov/dms-sysmon/main/plugin/assets/popout.png"
 }

--- a/plugins/rtabulov-sysmon.json
+++ b/plugins/rtabulov-sysmon.json
@@ -1,0 +1,14 @@
+{
+    "id": "sysmon",
+    "name": "Sysmon",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/rtabulov/dms-sysmon",
+    "path": "plugin",
+    "author": "rassul",
+    "description": "Compact DankBar Pill of system resource Items with a graph Popout",
+    "dependencies": ["dgop"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/rtabulov/dms-sysmon/main/plugin/assets/pill.png"
+}


### PR DESCRIPTION
## Summary

- Adds `plugins/rtabulov-sysmon.json` for [rtabulov/dms-sysmon](https://github.com/rtabulov/dms-sysmon) (`path: plugin`)
- Compact DankBar Pill of system-resource Items with CPU/memory/network graph Popout
- Category `monitoring`; dependency `dgop`; compositors/distro `any`

## Test plan

- [ ] `python3 .github/generate.py --validate`
- [ ] `python3 .github/validate_links.py`
- [ ] Confirm `id`/`name` match `plugin/plugin.json` (`sysmon` / `Sysmon`)
- [ ] Confirm screenshot URL loads