### PR TITLE
[plugin] Add System Monitor

### DIFF
--- a/plugins/chr314-system-monitor.json
+++ b/plugins/chr314-system-monitor.json
@@ -1,0 +1,13 @@
+{
+  "id": "systemMonitor",
+  "name": "System Monitor",
+  "capabilities": ["dankbar-widget"],
+  "category": "monitoring",
+  "repo": "https://github.com/chr314/dms-system-monitor",
+  "author": "Christoforos Aslanov",
+  "description": "Real-time CPU, temperature, RAM, network, disk and GPU line charts for the DankBar",
+  "dependencies": ["dgop"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/chr314/dms-system-monitor/refs/heads/master/screenshots/popup.png"
+}


### PR DESCRIPTION
Adds System Monitor, real time line charts for CPU usage, CPU temperature, RAM, network, disk I/O and GPU temperature in the DankBar, with a detailed popup on click.
Each metric can be toggled individually with optional icon, live value and custom colors, chart width and history length are configurable. 
Using dgop service for the data.