### PR TITLE
[plugin] Add Dank Jobs

### DIFF
--- a/plugins/ianptkcs-djobs.json
+++ b/plugins/ianptkcs-djobs.json
@@ -1,0 +1,13 @@
+{
+    "id": "djobs",
+    "name": "Dank Jobs",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/TabelaDev/dank-jobs-plugin",
+    "author": "Ian Soares",
+    "description": "Shows the next pending djobs job in the bar and lists all pending jobs in a popout, with status dots and auto-refresh.",
+    "dependencies": ["djobs"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/TabelaDev/dank-jobs-plugin/main/plugin-screenshot.png"
+}


### PR DESCRIPTION
## Plugin: Dank Jobs (djobs)

Adds the **Dank Jobs** widget plugin — a DankBar widget for the
[djobs](https://github.com/ianptkcs/djobs) TUI.

### What it does

- Bar pill shows the next pending job (name + when), or "sem jobs pendentes".
- Popout lists all pending jobs with status dots (green = active, yellow =
  paused), a refresh button and auto-refresh every 60s.
- Pulls data from the `djobs` binary via `ipc --json` — no daemon, no DB.

### Repo

https://github.com/TabelaDev/dank-jobs-plugin

- `plugin.json` `id`/`name` (`djobs` / `Dank Jobs`) match the registry entry.
- Screenshot URL reachable (raw on master).
- Requires DMS >= 1.2.0 (`requires_dms`).
- Depends on the `djobs` binary (in `dependencies`).