### PR TITLE
[plugin] Add Dank Software Depot

### DIFF
--- a/plugins/vinceecniv-dank-software-depot.json
+++ b/plugins/vinceecniv-dank-software-depot.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankSoftwareDepot",
+    "name": "Dank Software Depot",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/vinceecniv/DankSoftwareDepot",
+    "author": "Vincent Blok",
+    "description": "Software & updates center: rich update cards with release notes, app store for Fedora/Flathub/AppImage with ratings and reviews, installed-software management, firmware updates and an action log",
+    "dependencies": ["python3", "python3-gobject", "flatpak", "dnf5"],
+    "compositors": ["any"],
+    "distro": ["fedora"],
+    "screenshot": "https://raw.githubusercontent.com/vinceecniv/DankSoftwareDepot/main/screenshot.png",
+    "requires_dms": ">=1.6.0"
+}

--- a/plugins/vinceecniv-dank-software-depot.json
+++ b/plugins/vinceecniv-dank-software-depot.json
@@ -10,5 +10,5 @@
     "compositors": ["any"],
     "distro": ["fedora"],
     "screenshot": "https://raw.githubusercontent.com/vinceecniv/DankSoftwareDepot/main/screenshot.png",
-    "requires_dms": ">=1.6.0"
+    "requires_dms": ">=1.5.0"
 }


### PR DESCRIPTION
Adds **Dank Software Depot** — a software & updates center plugin for DMS.

- Rich update cards with release notes, held & delayed updates, live progress with ETA
- App store across Fedora repos, Flathub and an AppImage catalog, with ODRS ratings and reviews
- Installed-software management (uninstall, hold, downgrade, AppImage GitHub update sources)
- Firmware updates (fwupd) and a persistent action log
- UI in English, Dutch, German and French

Status: beta. Fedora-based distros only for now (`distro: ["fedora"]`) — the dnf5/AppStream parts are Fedora-specific; the plugin shows a warning banner on other distros.

Repo: https://github.com/vinceecniv/DankSoftwareDepot
`id`/`name` match the repo's `plugin.json`; `.github/generate.py --validate` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)