### PR TITLE
[plugin] Add dms-vikunja task management

### DIFF
--- a/plugins/arqueon-dms-vikunja.json
+++ b/plugins/arqueon-dms-vikunja.json
@@ -1,0 +1,36 @@
+{
+    "id": "dmsVikunja",
+    "name": "dms-vikunja",
+    "capabilities": [
+        "daemon",
+        "dankbar-widget",
+        "control-center",
+        "notifications"
+    ],
+    "category": "productivity",
+    "repo": "https://github.com/arqueon/dms-vikunja",
+    "author": "arqueon",
+    "description": "Manage Vikunja projects and tasks from DankBar with nested project and label views, due dates, priorities, attachments, and notifications.",
+    "version": "0.1.0",
+    "type": "composite",
+    "icon": "task_alt",
+    "components": {
+        "daemon": "./VikunjaDaemon.qml",
+        "widget": "./VikunjaWidget.qml"
+    },
+    "settings": "./Settings.qml",
+    "startupCheck": "./StartupCheck.qml",
+    "requires_dms": ">=1.5.0",
+    "dependencies": [
+        "python3",
+        "secret-tool",
+        "notify-send"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-vikunja/main/assets/screenshot.png"
+}


### PR DESCRIPTION
## Summary

Adds **dms-vikunja**, a composite DankMaterialShell plugin for managing Vikunja projects and tasks from DankBar.

Key features include nested project filtering, label views, task creation and editing, completion status, due-date shortcuts and calendar, priorities, attachments, sorting, persistent cache, and due/overdue notifications. The adapter supports Vikunja API v1 and v2 (including Vikunja 2.4+).

## Validation

- python3 .github/generate.py --validate
- python3 .github/validate_links.py
- node tests/test-vikunja.js
- python3 -m unittest -v tests/test_api.py (6 tests; mock v1/v2 servers)
- qmllint on the reusable QML components
- loaded and exercised in DankMaterialShell 1.5.0

The public screenshot contains only synthetic task and project data.