### PR TITLE
[plugin] Add Audio Output Monitor

### DIFF
--- a/plugins/thiswod-audio-output-monitor.json
+++ b/plugins/thiswod-audio-output-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "audioOutputMonitor",
+    "name": "Audio Output Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "audio",
+    "repo": "https://github.com/thiswod/dank-audio-output-monitor",
+    "author": "thiswod",
+    "description": "Identify applications currently or recently using audio output, including short-lived notification sounds.",
+    "dependencies": ["pactl", "pw-mon"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/thiswod/dank-audio-output-monitor/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds **Audio Output Monitor**, a DankBar widget that identifies applications currently or recently using audio output. It captures short-lived PipeWire streams so notification sounds remain visible after playback ends.

- Repository: https://github.com/thiswod/dank-audio-output-monitor
- Category: Audio
- Capabilities: DankBar widget
- Dependencies: pactl, pw-mon
- Compositors: any
- Official registry structure validation passes locally
- Repository, plugin manifest, and screenshot URLs were verified