### PR TITLE
[plugin] Update Dank Software Depot: add Debian/Ubuntu and Arch

### DIFF
--- a/plugins/vinceecniv-dank-software-depot.json
+++ b/plugins/vinceecniv-dank-software-depot.json
@@ -1,14 +1,30 @@
 {
     "id": "dankSoftwareDepot",
     "name": "Dank Software Depot",
-    "capabilities": ["dankbar-widget"],
+    "capabilities": [
+        "dankbar-widget"
+    ],
     "category": "system",
     "repo": "https://github.com/vinceecniv/DankSoftwareDepot",
     "author": "Vincent Blok",
-    "description": "Software & updates center: rich update cards with release notes, app store for Fedora/Flathub/AppImage with ratings and reviews, installed-software management, firmware updates and an action log",
-    "dependencies": ["python3", "python3-gobject", "flatpak", "dnf5"],
-    "compositors": ["any"],
-    "distro": ["fedora"],
+    "description": "Software & updates center: rich update cards with release notes, app store for system repos/Flathub/AppImage with ratings and reviews, installed-software management, firmware updates and an action log. Fedora first; Debian/Ubuntu and Arch experimental.",
+    "dependencies": [
+        "python3",
+        "python3-gobject",
+        "flatpak",
+        "python3-libdnf5 (Fedora)",
+        "python3-apt (Debian/Ubuntu)",
+        "pyalpm (Arch)"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "fedora",
+        "debian",
+        "ubuntu",
+        "arch"
+    ],
     "screenshot": "https://raw.githubusercontent.com/vinceecniv/DankSoftwareDepot/main/screenshot.png",
     "requires_dms": ">=1.5.0"
 }


### PR DESCRIPTION
Updates the Dank Software Depot entry for [v0.4.0](https://github.com/vinceecniv/DankSoftwareDepot/releases/tag/v0.4.0):

- `distro`: `fedora` → `fedora, debian, ubuntu, arch` — the plugin now detects the distro family and switches its whole package layer (transactions via python-apt / pyalpm, plus apt/pacman implementations of search, sizes, inventory and holds). Debian/Ubuntu and Arch are **experimental**: container-tested, shown with an in-app banner linking to the issue tracker. Fedora code paths are unchanged.
- `dependencies`: replaced `dnf5` with the per-distro package-manager bindings (`python3-libdnf5` / `python3-apt` / `pyalpm`).
- `description`: de-Fedora'd accordingly.

Per-version changelogs are available as tagged [GitHub Releases](https://github.com/vinceecniv/DankSoftwareDepot/releases), and the helper event protocol the backends implement is documented in [PROTOCOL.md](https://github.com/vinceecniv/DankSoftwareDepot/blob/main/PROTOCOL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)