### PR TITLE
[plugin] Add DMS Ketchup by Virtual Wolf 369

### DIFF
--- a/plugins/virtualwolf-369-dms-ketchup.json
+++ b/plugins/virtualwolf-369-dms-ketchup.json
@@ -1,0 +1,20 @@
+{
+    "id": "dmsKetchup",
+    "name": "DMS Ketchup",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/virtualwolf-369/dms-ketchup",
+    "path": "DankPomodoroTimer",
+    "author": "Virtual Wolf 369",
+    "description": "Ketchup timer with break modal, sounds, and manual resume controls",
+    "dependencies": [],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/virtualwolf-369/dms-ketchup/main/docs/screenshots/panel.png"
+}


### PR DESCRIPTION
Adds DMS Ketchup to the registry.

Plugin repo: https://github.com/virtualwolf-369/dms-ketchup
Plugin id: dmsKetchup

Per CONTRIBUTING.md, the registry entry matches the plugin's plugin.json and includes the required screenshot URL.