### PR TITLE
[plugin] Add Gaze Authentication

### DIFF
--- a/plugins/arqueon-dms-gaze-auth.json
+++ b/plugins/arqueon-dms-gaze-auth.json
@@ -1,0 +1,34 @@
+{
+    "id": "gazeAuth",
+    "name": "Gaze Authentication",
+    "capabilities": [
+        "control-center",
+        "authentication",
+        "command-execution"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/arqueon/dms-gaze-auth",
+    "author": "arqueon",
+    "description": "Inspect Gaze face-authentication health and DMS lock integration without changing PAM or biometric data.",
+    "version": "0.1.0",
+    "type": "widget",
+    "component": "./GazeAuth.qml",
+    "icon": "face",
+    "requires_dms": ">=1.5.0",
+    "dependencies": [
+        "bash",
+        "gaze",
+        "systemctl",
+        "xdg-open"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-gaze-auth/main/assets/screenshot.png",
+    "permissions": [
+        "process"
+    ]
+}


### PR DESCRIPTION
## Summary

- add the `gazeAuth` Control Center plugin
- classify it as a Utilities plugin for any compositor/distribution
- link its public repository and representative default-theme screenshot

## Validation

- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/arqueon-dms-gaze-auth.json python3 .github/validate_links.py`
- plugin repository CI: 9/9 tests, manifest schema, `shellcheck`, and `qmllint`
- runtime: loaded in DMS 1.5 development build on CachyOS/Niri with Gaze 0.2.9

The panel is read-only by default. It never edits PAM or biometric data; privileged installation and optional PAM preparation remain explicit terminal workflows.
