### PR TITLE
[plugin] Add Modern Clock desktop widget

### DIFF
--- a/plugins/beefsizzle-modernclock.json
+++ b/plugins/beefsizzle-modernclock.json
@@ -1,0 +1,13 @@
+{
+    "id": "modernClock",
+    "name": "Modern Clock",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/beefsizzle/ModernClockDMS",
+    "author": "beefsizzle",
+    "description": "Minimal desktop clock with a large day name over the date and time - a port of Prayag2's KDE Modern Clock plasmoid",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/beefsizzle/ModernClockDMS/main/docs/screenshot.png"
+}


### PR DESCRIPTION
A minimal desktop clock widget — port of Prayag2's KDE Modern Clock plasmoid. Screenshot in the README.