### PR TITLE
Add Mihomo VPN plugin

### DIFF
--- a/plugins/korbash-mihomo-vpn.json
+++ b/plugins/korbash-mihomo-vpn.json
@@ -1,7 +1,7 @@
 {
     "id": "mihomoVpn",
     "name": "Mihomo VPN",
-    "capabilities": ["vpn", "network", "dankbar-widget"],
+    "capabilities": ["dankbar-widget"],
     "category": "system",
     "repo": "https://github.com/korbash/mihomo-dms-widget",
     "path": "plugin",

--- a/plugins/korbash-mihomo-vpn.json
+++ b/plugins/korbash-mihomo-vpn.json
@@ -1,0 +1,15 @@
+{
+    "id": "mihomoVpn",
+    "name": "Mihomo VPN",
+    "capabilities": ["vpn", "network", "dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/korbash/mihomo-dms-widget",
+    "path": "plugin",
+    "author": "korbash",
+    "description": "Monitor and control Mihomo proxy groups, switch nodes, and run latency checks from DankBar",
+    "dependencies": ["mihomo", "curl", "jq"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/korbash/mihomo-dms-widget/main/assets/mihomo-vpn.png",
+    "requires_dms": ">=1.5.0"
+}


### PR DESCRIPTION
## Summary

- Add Mihomo VPN as a self-contained DankBar widget
- Declare Mihomo, curl, and jq runtime dependencies
- Include a representative default-theme screenshot with an expanded proxy group

## Validation

- `python3 .github/generate.py --validate`
- `python3 .github/validate_links.py`
- Clean-clone QML validation and component self-test
- Bundled bridge verified against a running Mihomo controller