### PR TITLE
Update dms-theme-sync: dbus-send dependency and accent options

### DIFF
--- a/plugins/arqueon-dms-theme-sync.json
+++ b/plugins/arqueon-dms-theme-sync.json
@@ -9,9 +9,10 @@
     "category": "appearance",
     "repo": "https://github.com/arqueon/dms-theme-sync",
     "author": "arqueon",
-    "description": "Make DMS the source of truth for appearance and propagate it to GTK, Qt, KDE, Fontconfig and XWayland apps — theme, light/dark, fonts, sizes, icons and cursor.",
+    "description": "Make DMS the source of truth for appearance and propagate it to GTK, Qt, KDE, Fontconfig and XWayland apps — theme, light/dark, fonts, sizes, icons and cursor, with optional Matugen-accent folder colors and Bibata-Material cursor variants.",
     "dependencies": [
-        "bash"
+        "bash",
+        "dbus-send"
     ],
     "compositors": [
         "any"


### PR DESCRIPTION
Sync the registry entry with dms-theme-sync v0.9.0 ([arqueon/dms-theme-sync@f0d3095](https://github.com/arqueon/dms-theme-sync/commit/f0d3095)):

- `dependencies`: add `dbus-send` — since the hot-reload work the plugin broadcasts the supported KDE/Qt change notifications (KGlobalSettings + KIconLoader) after each apply, and `plugin.json` already declares it.
- `description`: mention the optional Matugen-accent folder colors and the new Bibata-Material cursor variants.

No id/capability changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)