### PR TITLE
Update Audio Output Monitor dependencies

### DIFF
--- a/plugins/thiswod-audio-output-monitor.json
+++ b/plugins/thiswod-audio-output-monitor.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/thiswod/dank-audio-output-monitor",
     "author": "thiswod",
     "description": "Identify applications currently or recently using audio output, including short-lived notification sounds.",
-    "dependencies": ["pactl", "pw-mon"],
+    "dependencies": ["pactl", "pw-mon", "parec", "python3"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/thiswod/dank-audio-output-monitor/main/assets/screenshot.png"


### PR DESCRIPTION
Audio Output Monitor v1.3.0 now verifies actual per-stream PCM activity to ignore silent startup and prewarm streams. Update the registry dependencies to include parec and python3.