### PR TITLE
[plugin] Add Screen Recorder YS

### DIFF
--- a/plugins/smithyyang-screen-recorder-ys.json
+++ b/plugins/smithyyang-screen-recorder-ys.json
@@ -12,10 +12,10 @@
     "gpu-screen-recorder"
   ],
   "compositors": [
-    "hyprland"
+    "any"
   ],
   "distro": [
-    "arch"
+    "any"
   ],
   "requires_dms": ">=1.2.0",
   "screenshot": "https://raw.githubusercontent.com/smithyyang/dms-screen-recorder/main/assets/screenshot.png"

--- a/plugins/smithyyang-screen-recorder-ys.json
+++ b/plugins/smithyyang-screen-recorder-ys.json
@@ -1,0 +1,22 @@
+{
+  "id": "screenRecorderYS",
+  "name": "Screen Recorder YS",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/smithyyang/dms-screen-recorder",
+  "author": "youngshine",
+  "description": "GPU-accelerated monitor recording with VFR, quality and resolution controls, cursor capture, countdown, and independently selectable system and microphone audio.",
+  "dependencies": [
+    "gpu-screen-recorder"
+  ],
+  "compositors": [
+    "hyprland"
+  ],
+  "distro": [
+    "arch"
+  ],
+  "requires_dms": ">=1.2.0",
+  "screenshot": "https://raw.githubusercontent.com/smithyyang/dms-screen-recorder/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Add [dms-screen-recorder](https://github.com/smithyyang/dms-screen-recorder) to the registry.

GPU-accelerated Wayland monitor recording for DankMaterialShell powered by gpu-screen-recorder:

- monitor selection with native resolution detection
- VFR with configurable maximum FPS (15–120)
- Medium/High/Very High/Ultra quality presets
- native/1080p/720p output; H.264/HEVC/AV1/VP9 where supported
- MKV/MP4 containers; optional cursor capture
- independent system-audio and microphone toggles mixed into one track
- optional 3s/5s countdown; DankBar REC indicator and stop action

Works on Hyprland (tested on CachyOS). Requires: gpu-screen-recorder.