### PR TITLE
screenRecorder: v1.5.0 — audio modes, daemon + control-center capabilities

### DIFF
--- a/plugins/arqueon-screenrecorder.json
+++ b/plugins/arqueon-screenrecorder.json
@@ -2,12 +2,14 @@
     "id": "screenRecorder",
     "name": "Screen Recorder",
     "capabilities": [
-        "dankbar-widget"
+        "daemon",
+        "dankbar-widget",
+        "control-center"
     ],
     "category": "utilities",
     "repo": "https://github.com/arqueon/dms-screen-recorder",
     "author": "arqueon",
-    "description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor. Supports IPC keybinds.",
+    "description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor. Audio modes: system audio, microphone, both mixed, or both as separate tracks. IPC keybinds and Control Center toggle.",
     "dependencies": [
         "gpu-screen-recorder"
     ],
@@ -17,5 +19,6 @@
     "distro": [
         "any"
     ],
-    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-screen-recorder/main/assets/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-screen-recorder/main/assets/screenshot.png",
+    "version": "1.5.0"
 }


### PR DESCRIPTION
Updates the `screenRecorder` entry ([repo](https://github.com/arqueon/dms-screen-recorder)):

- Adds the previously omitted `version` field (now `1.5.0`).
- `capabilities` now matches the plugin manifest: `daemon`, `dankbar-widget`, `control-center` (the plugin is composite; the Control Center widget landed in arqueon/dms-screen-recorder#16).
- Description refreshed for the v1.5.0 audio modes: system audio, microphone, both mixed into one track, or both as separate tracks in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)