### PR TITLE
[plugin] Add CodeBurn

### DIFF
--- a/plugins/gtheys-codeburn.json
+++ b/plugins/gtheys-codeburn.json
@@ -1,0 +1,13 @@
+{
+    "id": "codeburn",
+    "name": "CodeBurn",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/gtheys/dms-codeburn",
+    "author": "Geert Theys",
+    "description": "Monitor AI coding assistant token usage and costs from DankBar — cost pill, popup dashboard with insights, budget alerts, and multi-currency conversion",
+    "dependencies": ["codeburn", "bash", "jq"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/gtheys/dms-codeburn/main/docs/screenshot.png"
+}


### PR DESCRIPTION
## CodeBurn

Monitor AI coding assistant token usage and costs from DankBar — a port of the [CodeBurn GNOME extension](https://github.com/getagentseal/codeburn) to DankMaterialShell.

- **Bar pill**: flame icon + current-period cost (compact mode: icon only)
- **Popup dashboard**: provider tabs, hero summary, period tabs (Today → 6 Months), insight views (Activity / Trend / Forecast / Pulse / Stats), 19-day token chart, budget alerts, optimize-findings shortcut
- **19 currencies** with FX conversion (frankfurter.dev), persisted via the codeburn CLI
- **Data**: 100% local — single `codeburn status --format menubar-json` call via a bash adapter (15s timeout, structured error kinds)

Repo: https://github.com/gtheys/dms-codeburn

## Validation

- `python3 .github/generate.py --validate` → Validation successful
- `id`/`name` verified to match `plugin.json` (`codeburn` / `CodeBurn`)
- Screenshot, repo, and plugin.json URLs all return 200