### PR TITLE
Update Dankmail plugin to canonical repository

### DIFF
--- a/plugins/arqueon-dankmail-unread.json
+++ b/plugins/arqueon-dankmail-unread.json
@@ -3,11 +3,12 @@
     "name": "Dankmail Unread",
     "capabilities": ["dankbar-widget"],
     "category": "utilities",
-    "repo": "https://github.com/arqueon/dms-dankmail",
+    "repo": "https://github.com/arqueon/dankmail",
+    "path": "dms-plugin",
     "author": "arqueon",
-    "description": "Live unread mail badge for dankmail with a triage popout: recent inbox with per-message actions, compose, sync and DND. Requires the dmail daemon.",
+    "description": "The DankMaterialShell companion shipped with Dankmail: live unread status and quick triage powered by the same dmail daemon.",
     "dependencies": ["dmail"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/arqueon/dms-dankmail/main/assets/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/arqueon/dankmail/main/assets/screenshot.png"
 }


### PR DESCRIPTION
## Summary

- Point the existing dankmailUnread entry to the canonical arqueon/dankmail repository.
- Set path to dms-plugin, where the DMS companion is maintained alongside the daemon.
- Keep the existing plugin ID and registry file instead of creating a duplicate entry.
- Update the description and screenshot URL to the canonical project.

## Validation

- python3 .github/generate.py --validate
- Targeted validate_links.py for plugins/arqueon-dankmail-unread.json
- Remote validation against the canonical repository, dms-plugin/plugin.json, README, and screenshot

The canonical plugin is published as Dankmail DMS plugin 0.2.0. The former dms-dankmail repository remains only as historical reference.