### PR TITLE
chore(plugins): bump gaze-auth entry to 0.4.0

### DIFF
--- a/plugins/arqueon-dms-gaze-auth.json
+++ b/plugins/arqueon-dms-gaze-auth.json
@@ -10,11 +10,11 @@
     "repo": "https://github.com/arqueon/dms-gaze-auth",
     "author": "arqueon",
     "description": "Inspect Gaze face-authentication health and DMS lock integration without changing PAM or biometric data.",
-    "version": "0.1.0",
+    "version": "0.4.0",
     "type": "widget",
     "component": "./GazeAuth.qml",
     "icon": "face",
-    "requires_dms": ">=1.5.0",
+    "requires_dms": ">=1.6.0",
     "dependencies": [
         "bash",
         "gaze",


### PR DESCRIPTION
Syncs the registry entry with the [dms-gaze-auth v0.4.0 release](https://github.com/arqueon/dms-gaze-auth/pull/2):

- version 0.1.0 → 0.4.0
- requires_dms >= 1.5.0 → >= 1.6.0 (simultaneous lock mode + auth HUD)

No schema changes; entry remains otherwise identical.