### PR TITLE
[plugin] Add Attention Badges

### DIFF
--- a/plugins/mkoester-attention-badges.json
+++ b/plugins/mkoester-attention-badges.json
@@ -1,0 +1,14 @@
+{
+    "id": "attentionBadges",
+    "name": "Attention Badges",
+    "capabilities": ["daemon", "dankbar-widget", "ipc"],
+    "category": "productivity",
+    "repo": "https://github.com/mkoester/dms-attention-badges",
+    "author": "Mirko Köster",
+    "description": "Per-app bar badges for what happened since you last focused that app, cleared by focusing its window — not an unread counter. Every watched app is a small JSON provider file, so the plugin itself knows nothing about any particular program.",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/mkoester/dms-attention-badges/main/docs/screenshot.png",
+    "requires_dms": ">=1.5.0"
+}


### PR DESCRIPTION
Adds **Attention Badges** — per-app bar badges for *what happened since you last focused that app*, cleared by focusing its window. Deliberately not an unread counter: a mailbox with 4000 unread messages shows nothing until something new arrives.

The plugin is a **host, not a feature**: it knows how to watch things and nothing about what. Every watched app is a small JSON provider file in `~/.config/DankMaterialShell/attention-providers/`, so a fresh install badges nothing and nothing in the plugin names any particular program. Two source kinds — notifications (accumulates, cleared by window focus) and a command polled on an interval (replaced wholesale each poll, so it needs no reset, which is what an app you sit *inside* requires).

- Repo: https://github.com/mkoester/dms-attention-badges (MIT)
- Two worked example providers, each its own repo: [Thunderbird](https://github.com/mkoester/dms-attention-badges-tb) (new mail per account) and [herdr](https://github.com/mkoester/dms-attention-badges-herdr) (panes whose agent is waiting)

Validated locally before opening: `python3 .github/generate.py --validate` and `.github/validate_links.py` both pass, each with a deliberately broken copy run first to confirm the checks actually fire on this entry.