### PR TITLE
[plugin] Add Pure Lyrics

### DIFF
--- a/plugins/lildengzi-purelyrics.json
+++ b/plugins/lildengzi-purelyrics.json
@@ -1,0 +1,19 @@
+{
+    "id": "pureLyrics",
+    "name": "Pure Lyrics",
+    "capabilities": [
+        "desktop-widget"
+    ],
+    "category": "media",
+    "repo": "https://github.com/lildengzi/pureLyrics",
+    "author": "lildengzi",
+    "description": "A minimal floating desktop widget that displays real-time synced lyrics from multiple sources.",
+    "dependencies": [],
+    "compositors": [
+        "niri"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/lildengzi/pureLyrics/main/screenshot.png"
+}

--- a/plugins/lildengzi-purelyrics.json
+++ b/plugins/lildengzi-purelyrics.json
@@ -10,7 +10,7 @@
     "description": "A minimal floating desktop widget that displays real-time synced lyrics from multiple sources.",
     "dependencies": [],
     "compositors": [
-        "niri"
+        "any"
     ],
     "distro": [
         "any"


### PR DESCRIPTION
Add the **Pure Lyrics** desktop widget plugin.

**Pure Lyrics** is a minimal floating desktop widget that displays real-time synced lyrics from multiple sources (LRCLIB, LRC API, Musixmatch, Navidrome). No menus, no bloat — just lyrics, highly customizable.

- Type: desktop-widget
- Compositors: niri
- Source: https://github.com/lildengzi/pureLyrics
- Validated locally with `generate.py --validate` and `validate_links.py`