### PR TITLE
[plugin] Add Storage Monitor

### DIFF
--- a/plugins/youngjurry-storage-monitor.json
+++ b/plugins/youngjurry-storage-monitor.json
@@ -1,0 +1,21 @@
+{
+  "id": "storageMonitor",
+  "name": "Storage Monitor",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "system",
+  "repo": "https://github.com/YoungJurry/dms-storage-monitor",
+  "author": "youngshine",
+  "description": "Monitor total and per-partition storage usage with progress bars, and mount or unmount internal and removable drives via udisks2.",
+  "dependencies": [
+    "udisks2"
+  ],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/YoungJurry/dms-storage-monitor/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Add [dms-storage-monitor](https://github.com/YoungJurry/dms-storage-monitor) to the registry.

Storage usage monitor and mount/unmount manager for DankMaterialShell:

- total and per-partition usage (used/total/percent) with progress bars
- mount and unmount internal and removable drives via udisks2 (polkit authorization)
- smart filtering hides EFI, Windows recovery and reserved partitions (like most file managers)
- volume labels, auto-refresh interval options, confirm-before-unmount

Requires: udisks2.