### PR TITLE
[plugin] Add Hyprwhspr Voice Overlay

### DIFF
--- a/plugins/lucianosrp-hyprwhspr-voice-overlay.json
+++ b/plugins/lucianosrp-hyprwhspr-voice-overlay.json
@@ -8,7 +8,7 @@
     "firstParty": false,
     "description": "On-screen voice visualizer for hyprwhspr. A large mirrored equalizer, driven by the live microphone level, that fades in only while hyprwhspr is recording.",
     "dependencies": ["hyprwhspr"],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/lucianosrp/HyprwhsprVoiceOverlay/main/screenshot.png",
     "requires_dms": ">=1.2.0"

--- a/plugins/lucianosrp-hyprwhspr-voice-overlay.json
+++ b/plugins/lucianosrp-hyprwhspr-voice-overlay.json
@@ -1,0 +1,15 @@
+{
+    "id": "hyprwhsprVoiceOverlay",
+    "name": "Hyprwhspr Voice Overlay",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/lucianosrp/HyprwhsprVoiceOverlay",
+    "author": "lucianosrp",
+    "firstParty": false,
+    "description": "On-screen voice visualizer for hyprwhspr. A large mirrored equalizer, driven by the live microphone level, that fades in only while hyprwhspr is recording.",
+    "dependencies": ["hyprwhspr"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/lucianosrp/HyprwhsprVoiceOverlay/main/screenshot.png",
+    "requires_dms": ">=1.2.0"
+}

--- a/plugins/lucianosrp-hyprwhspr-voice-overlay.json
+++ b/plugins/lucianosrp-hyprwhspr-voice-overlay.json
@@ -5,7 +5,6 @@
     "category": "utilities",
     "repo": "https://github.com/lucianosrp/HyprwhsprVoiceOverlay",
     "author": "lucianosrp",
-    "firstParty": false,
     "description": "On-screen voice visualizer for hyprwhspr. A large mirrored equalizer, driven by the live microphone level, that fades in only while hyprwhspr is recording.",
     "dependencies": ["hyprwhspr"],
     "compositors": ["any"],

--- a/plugins/lucianosrp-hyprwhspr-voice-overlay.json
+++ b/plugins/lucianosrp-hyprwhspr-voice-overlay.json
@@ -11,5 +11,5 @@
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/lucianosrp/HyprwhsprVoiceOverlay/main/screenshot.png",
-    "requires_dms": ">=1.2.0"
+    "requires_dms": ">=1.5.0"
 }


### PR DESCRIPTION
A desktop widget for [hyprwhspr](https://github.com/goodroot/hyprwhspr): a mirrored equalizer, driven by the live microphone level, that fades in only while dictation is recording.

Repo: https://github.com/lucianosrp/HyprwhsprVoiceOverlay

`generate.py --validate` and `validate_links.py` both pass locally.