### PR TITLE
[plugin] Add Scratchpad Helper

### DIFF
--- a/plugins/fluxwrk-scratchpad-helper.json
+++ b/plugins/fluxwrk-scratchpad-helper.json
@@ -1,0 +1,24 @@
+{
+    "id": "scratchpadHelper",
+    "name": "Scratchpad Helper",
+    "capabilities": [
+        "daemon",
+        "dankbar-widget",
+        "control-center"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/fluxwrk/dms-scratchpad-helper",
+    "author": "fluxwrk",
+    "description": "A visual scratchpad picker for MangoWM with cached previews and optional managed named scratchpads",
+    "dependencies": [
+        "mmsg"
+    ],
+    "compositors": [
+        "mangowc"
+    ],
+    "distro": [
+        "any"
+    ],
+    "requires_dms": ">=1.5.0",
+    "screenshot": "https://raw.githubusercontent.com/fluxwrk/dms-scratchpad-helper/main/assets/scratchpad-picker.png"
+}


### PR DESCRIPTION
Adds Scratchpad Helper, a MangoWM scratchpad picker for DankMaterialShell with cached previews and optional managed named scratchpads.

- DankBar widget
- Control Center integration
- Standard and managed named scratchpad support
- Cached window previews
- MangoWC support

Validated with:

- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/fluxwrk-scratchpad-helper.json python3 .github/validate_links.py`