### PR TITLE
[plugin] Add Music Theme

### DIFF
--- a/plugins/felipeadeildo-music-theme.json
+++ b/plugins/felipeadeildo-music-theme.json
@@ -15,5 +15,5 @@
     "distro": [
         "any"
     ],
-    "screenshot": "https://raw.githubusercontent.com/felipeadeildo/dms-music-theme/master/assets/screenshot.png"
+    "screenshot": "https://raw.githubusercontent.com/felipeadeildo/dms-music-theme/main/assets/screenshot.png"
 }

--- a/plugins/felipeadeildo-music-theme.json
+++ b/plugins/felipeadeildo-music-theme.json
@@ -1,0 +1,19 @@
+{
+    "id": "musicTheme",
+    "name": "Music Theme",
+    "capabilities": [
+        "daemon"
+    ],
+    "category": "appearance",
+    "repo": "https://github.com/felipeadeildo/dms-music-theme",
+    "author": "felipeadeildo",
+    "description": "Themes your system from the currently playing album art",
+    "dependencies": [],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/felipeadeildo/dms-music-theme/master/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds my plugin, Music Theme (https://github.com/felipeadeildo/dms-music-theme).

It retints the system theme (GTK/Qt/terminals/editors) from the album art of whatever's currently playing, using DMS's own matugen pipeline (`Theme.setDesiredTheme`) instead of a wallpaper file, so your actual wallpaper is never touched. Reverts to the wallpaper theme automatically when playback stops.

Ran `generate.py --validate` and `validate_links.py` locally, both pass.