### PR TITLE
[plugin] Add Dcal Tasks launcher

### DIFF
--- a/plugins/antonykor-dcal-tasks.json
+++ b/plugins/antonykor-dcal-tasks.json
@@ -1,0 +1,13 @@
+{
+    "id": "dcalTasks",
+    "name": "Dcal Tasks",
+    "capabilities": ["launcher"],
+    "category": "productivity",
+    "repo": "https://github.com/AntonyKor/dcal-tasks-launcher",
+    "author": "AntonyKor",
+    "description": "List, search, create, and complete dcal tasks from the launcher, with natural language due dates.",
+    "dependencies": ["dcal"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/AntonyKor/dcal-tasks-launcher/master/docs/screenshot.png"
+}


### PR DESCRIPTION
Adds [Dcal Tasks](https://github.com/AntonyKor/dcal-tasks-launcher), a launcher plugin for [dcal](https://github.com/AvengeMedia/dankcalendar) tasks.

Type the trigger to list open tasks, type further to search them, and press Enter to toggle a task complete or reopen it. `Create task: <text>` creates a task in the configured list, and a date phrase at the end of what you type — `; publish tasks plugin tomorrow at 6PM` — becomes the due date. Numeric dates like `2/9` are read in the locale's own day/month order, and times render 12- or 24-hour to match `SettingsData.use24HourClock`.

No `jq` dependency — task and calendar JSON is parsed in QML/JS. Requires DMS >= 1.5.0 and dcal with its daemon running.

Validated locally against the current `master` of this repo:

- `python3 .github/generate.py --validate` — passes
- `python3 .github/validate_links.py` — passes (id and name match the repository `plugin.json`, screenshot and repo URLs reachable)

The repository default branch is `master`, so `validate_links.py` logs three 404 retries against `main` before falling back and succeeding.