### PR TITLE
[plugin] Add EnderPulse

### DIFF
--- a/plugins/iquantecho-enderpulse.json
+++ b/plugins/iquantecho-enderpulse.json
@@ -1,0 +1,25 @@
+{
+  "id": "enderPulse",
+  "name": "EnderPulse",
+  "capabilities": [
+    "daemon",
+    "dankbar-widget",
+    "desktop-widget",
+    "variants"
+  ],
+  "category": "appearance",
+  "repo": "https://github.com/iquantecho/enderpulse",
+  "author": "iquantecho",
+  "description": "A responsive Cava visualizer for DankBar and the desktop",
+  "dependencies": [
+    "cava"
+  ],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "requires_dms": ">=1.5.1",
+  "screenshot": "https://raw.githubusercontent.com/iquantecho/enderpulse/main/docs/enderpulse-preview.png"
+}


### PR DESCRIPTION
Adds EnderPulse 1.1.0, a Cava visualizer for DankBar and the desktop.

Validation completed:
- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/iquantecho-enderpulse.json python3 .github/validate_links.py`
- Registry metadata matches the public `plugin.json`; repository and screenshot URLs are reachable.