### PR TITLE
fix(grimblast): point at a live mirror, upstream repo was deleted

### DIFF
--- a/plugins/taylantatli-grimblast.json
+++ b/plugins/taylantatli-grimblast.json
@@ -3,13 +3,13 @@
     "name": "Grimblast",
     "capabilities": ["screenshot-tool", "dankbar-widget"],
     "category": "utilities",
-    "repo": "https://github.com/TaylanTatli/dms-plugins",
+    "repo": "https://github.com/bernardopg/dms-plugins-grimblast",
     "path": "grimblast",
     "author": "Taylan TATLI",
     "description": "Quick screenshot menu for grimblast with multiple capture modes",
     "dependencies": ["grimblast"],
     "compositors": ["hyprland"],
     "distro": ["any"],
-    "screenshot": "https://raw.githubusercontent.com/TaylanTatli/dms-plugins/refs/heads/master/grimblast/screenshot.png",
+    "screenshot": "https://raw.githubusercontent.com/bernardopg/dms-plugins-grimblast/refs/heads/master/grimblast/screenshot.png",
     "requires_dms": ">=0.1.18"
 }


### PR DESCRIPTION
The `grimblast` entry points at `TaylanTatli/dms-plugins`, which no longer exists:

```
$ git fetch https://github.com/TaylanTatli/dms-plugins
remote: Repository not found.
fatal: repository not found
```

The account is still active — only this repo is gone, and there is no rename redirect (plain 404). So anyone installing `grimblast` today gets a hard failure, and every existing install fails on update forever. The `screenshot` URL is dead for the same reason, so the entry also renders without a preview.

This points both URLs at a mirror I published from an intact local clone made before the repo disappeared.

**On provenance,** since that matters for a registry:

- All six original commits are preserved, authored by Taylan Tatlı — not a squashed re-upload.
- The MIT `LICENSE` is unchanged, copyright intact.
- No plugin file was modified. `Grimblast.qml`, `GrimblastSettings.qml`, `plugin.json` and `screenshot.png` are byte-identical to what the registry served (verified by sha256).
- The only commit I added marks the repo as a mirror in the `README`, which DMS does not load.
- `author` stays `Taylan TATLI` in this entry — I am not claiming authorship, just keeping it reachable.

There is a second copy in the wild (`acarlton5/HYPEPLUGIN-grimblast`) but it is a bulk scrape of ~30 registry plugins into a third-party shell project, flattened to a single `Initial import` commit with the original authorship gone. I would not point a registry at it.

Happy to take any alternative you prefer — including dropping the entry, or transferring the mirror to the org — and I will step aside immediately if the original author republishes upstream.