### PR TITLE
Add Hermes Command Deck

### DIFF
--- a/plugins/kepeto-hermes-command-deck.json
+++ b/plugins/kepeto-hermes-command-deck.json
@@ -8,7 +8,7 @@
   "category": "utilities",
   "repo": "https://github.com/kepeto/dms-hermes-command-deck",
   "author": "Kepeto",
-  "description": "A focused local command deck for Hermes Agent and DankMaterialShell.",
+  "description": "Streaming Hermes Agent command deck with edge-dock or centered-modal surfaces, tool activity, and persistent local chat history.",
   "dependencies": [
     "curl",
     "Hermes Agent"

--- a/plugins/kepeto-hermes-command-deck.json
+++ b/plugins/kepeto-hermes-command-deck.json
@@ -1,0 +1,24 @@
+{
+  "id": "hermesCommandDeck",
+  "name": "Hermes Command Deck",
+  "capabilities": [
+    "ai",
+    "slideout"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/kepeto/dms-hermes-command-deck",
+  "author": "Kepeto",
+  "description": "A focused local command deck for Hermes Agent and DankMaterialShell.",
+  "dependencies": [
+    "curl",
+    "Hermes Agent"
+  ],
+  "compositors": [
+    "any"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/kepeto/dms-hermes-command-deck/main/assets/hermes-command-deck-sidebar.png",
+  "requires_dms": ">=1.4.0"
+}


### PR DESCRIPTION
## Summary

Add Hermes Command Deck to the DankMaterialShell plugin registry.

Hermes Command Deck is a local AI command deck for Hermes Agent and DankMaterialShell. It requires `curl` and a configured local Hermes Agent gateway.

## Related plugin and distinction

We found the existing [Dank Hermes](https://github.com/huangkaile22-prog/dankhermes) entry (`dankHermes`) and its registry issue [#632](https://github.com/AvengeMedia/dms-plugin-registry/issues/632). Both plugins target the same local Hermes API and therefore have substantial functional overlap: chat sidebar, settings, conversation history, and IPC control.

Hermes Command Deck is a separate implementation with these concrete differences:

- supports both an edge-dock surface and a centered modal;
- streams responses and exposes tool-activity progress while Hermes works;
- persists local history and session state through DMS plugin state, with migration from the older `kepetoRelay`/`hermesChat` state IDs;
- provides request cancellation and guarded scroll-to-bottom behavior;
- exposes the `hermesCommandDeck` IPC namespace and richer settings for display mode, panel width, timestamps, and CLI commands;
- includes a startup check for `curl` and a declared `curl` dependency.

We are explicitly flagging the overlap rather than presenting this as an unrelated plugin. Please advise whether the registry prefers this as a separate implementation, wants coordination with the Dank Hermes maintainer, or would rather consolidate the entries. We are happy to close this PR if a duplicate listing is not appropriate.

## Validation

- `python3 .github/generate.py --validate`
- `CHANGED_PLUGINS=plugins/kepeto-hermes-command-deck.json python3 .github/validate_links.py`
- Current repository `plugin.json` id/name match the registry entry.
- Screenshot URL points to the current tracked sidebar screenshot in the public plugin repository.