### PR TITLE
[plugin] Add Local Services

### DIFF
--- a/plugins/nyllre-dms-local-services.json
+++ b/plugins/nyllre-dms-local-services.json
@@ -1,0 +1,22 @@
+{
+    "id": "localServices",
+    "name": "Local Services",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "monitoring",
+    "repo": "https://github.com/NyllRE/dms-plugins",
+    "path": "plugins/local-services",
+    "author": "NyllRE",
+    "description": "Passive discovery of local TCP services (ports 1000-9999): dev servers auto-surface with live favicons; pin ports or ranges to track them on the DankBar.",
+    "dependencies": [
+        "iproute2"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/NyllRE/dms-plugins/master/plugins/local-services/preview.webp"
+}


### PR DESCRIPTION
### TL;DR
A very simple monitoring tool to see what services you have running on your machine.

![preview](https://github.com/NyllRE/dms-plugins/raw/master/plugins/local-services/preview.webp)

Adds `plugins/nyllre-dms-local-services.json` for [dms-plugins](https://github.com/NyllRE/dms-plugins), a monorepo entry at path `plugins/local-services`.

## What it does

Local Services passively discovers locally listening TCP services (ports 1000-9999) and surfaces them in the DankBar:

- **Automatic dev server detection**: Vite, Next, Nuxt/Nitro, SvelteKit, Astro, Django, Rails, Laravel, cargo, dotnet, and ~50 other common dev servers are classified as DEV from process command lines and auto-appear on the bar with their live favicon. No wrappers or changed launch commands.
- **Favicon discovery**: served `<link rel=icon>` → `/favicon.ico` / `apple-touch-icon.png`; ICO containers normalized (embedded PNG extraction or ffmpeg conversion) so no white canvas artifacts. Cached per-server and automatically re-fetched when a different process takes over a port.
- **Exact port watches**: stay visible when offline (dimmed sleep badge); **range watches** (e.g. `3000-3099`) show active members only.
- **Popup**: lists all discovered services: identity, port, classification chip (only when known — DEV/PREVIEW/SERVICE), pin/unpin inline, and expandable per-row technical details (pid, cwd, command, confidence, evidence).
- Read-only discovery (`ss` output + `/proc/<pid>` metadata, capped at 200 records); HTTP probes are localhost-only GETs with 2s timeout and 256KB cap.

## Notes

- Monorepo plugin: `"path": "plugins/local-services"`; registry `id`/`name` match that folder's `plugin.json`.
- Single dependency: `iproute2` (the `ss` tool).
- Compositors declared `["any"]`: the plugin uses only standard DMS APIs (PluginComponent, Process, Timer) with no compositor-specific integrations.
- Preview screenshot shows the popup open with live services on the bar.

Validation: `generate.py --validate` passes locally; repo and screenshot URLs verified reachable.