### PR TITLE
[plugin] Add MouthGuard

### DIFF
--- a/plugins/sitolam-mouthguard.json
+++ b/plugins/sitolam-mouthguard.json
@@ -1,0 +1,14 @@
+{
+  "id": "mouthGuard",
+  "name": "MouthGuard",
+  "capabilities": ["daemon", "dankbar-widget", "control-center"],
+  "category": "monitoring",
+  "repo": "https://github.com/sitolam/dms-plugins",
+  "path": "plugins/mouthguard",
+  "author": "sitolam",
+  "description": "Webcam mouth-closure tracker with alerts and session stats",
+  "dependencies": ["python3", "python-opencv", "python-openvino"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/sitolam/dms-plugins/main/plugins/mouthguard/screenshots/popout.png"
+}


### PR DESCRIPTION
Adds `plugins/sitolam-mouthguard.json`.

MouthGuard is a webcam mouth-closure tracker: it watches for a mouth left open (mouth breathing) and alerts after a configurable delay, then keeps per-session stats and a history of how much of the measured time the mouth was open. It is a DMS port of my browser app at https://github.com/sitolam/mouthguard.

Detection runs entirely on-device: MediaPipe Face Mesh through OpenVINO, on an Intel NPU where one is available and otherwise the iGPU or CPU. No calibration step, and no image data leaves the machine.

It lives in the same monorepo as my dankMenu entry (#784), so the listing uses `path` to point at `plugins/mouthguard`. `id` and `name` match that directory's `plugin.json` exactly (`mouthGuard` / `MouthGuard`).

Dependencies are `python3`, `python-opencv` and `python-openvino`; the plugin ships a startup check that reports which one is missing, and a Nix flake for NixOS users.