### PR TITLE
[plugin] Update dankMenu

### DIFF
--- a/plugins/sitolam-dankmenu.json
+++ b/plugins/sitolam-dankmenu.json
@@ -6,7 +6,7 @@
   "repo": "https://github.com/sitolam/dms-plugins",
   "path": "plugins/dankmenu",
   "author": "sitolam",
-  "description": "Omarchy-style root menu: one key to every command, with built-in search",
+  "description": "Omarchy-style root menu: one key to every command, with built-in search, conditional rows and live labels",
   "dependencies": [],
   "compositors": ["any"],
   "distro": ["any"],


### PR DESCRIPTION
Description update to an already-listed plugin — no new entry, no new files.

dankMenu 0.2.0 adds `labelCmd`, a condition kind whose stdout becomes the row's label, so a row can show a live value (a container's memory use, a temperature) rather than static text. The listed description still covered only the 0.1.0 feature set.

The new string matches the `description` now in the plugin's own `plugin.json`, so the registry listing and the plugin agree.

`id`, `name`, `repo`, `path` and `screenshot` are all unchanged.

Validation:

- `python3 .github/generate.py --validate` → `Validation successful!`
- `python3 .github/validate_links.py` → exit 0. `sitolam-dankmenu.json` passed. Two unrelated entries (`zhainy-timemanager`, `zhtlancer-cputhermalindicator`) reported connection errors on both their screenshot and repo URLs near the end of the run, which looks like rate limiting rather than genuinely dead links — flagging it in case it is useful, it is not caused by this PR.