### PR TITLE
[plugin] Add Dank Calendar Plus

### DIFF
--- a/plugins/luckjokerwang-dms-dankcalendar.json
+++ b/plugins/luckjokerwang-dms-dankcalendar.json
@@ -14,11 +14,7 @@
         "python3"
     ],
     "compositors": [
-        "niri",
-        "hyprland",
-        "sway",
-        "dwl",
-        "wayfire"
+        "any"
     ],
     "distro": [
         "any"

--- a/plugins/luckjokerwang-dms-dankcalendar.json
+++ b/plugins/luckjokerwang-dms-dankcalendar.json
@@ -1,0 +1,27 @@
+{
+    "id": "dankCalendarPlus",
+    "name": "Dank Calendar Plus",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/luckjokerwang/dms-dankcalendar",
+    "author": "luckjokerwang",
+    "description": "Next-event countdown & full tasks manager for dcal: dual-mode bar pill, interactive agenda & tasks popout with priority tagging and instant synchronization",
+    "dependencies": [
+        "dcal",
+        "jq",
+        "python3"
+    ],
+    "compositors": [
+        "niri",
+        "hyprland",
+        "sway",
+        "dwl",
+        "wayfire"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/luckjokerwang/dms-dankcalendar/main/assets/screenshot.png"
+}


### PR DESCRIPTION
### Plugin Submission

- **Plugin ID**: `dankCalendarPlus`
- **Name**: Dank Calendar Plus
- **Author**: luckjokerwang
- **Repository**: https://github.com/luckjokerwang/dms-dankcalendar
- **Category**: utilities
- **Capabilities**: `["dankbar-widget"]`
- **Description**: Next-event countdown & full tasks manager for dcal: dual-mode bar pill, interactive agenda & tasks popout with priority tagging and instant synchronization.

Added `plugins/luckjokerwang-dms-dankcalendar.json` per the contribution guidelines.