### PR TITLE
[plugin] Add Spotify Like

### DIFF
--- a/plugins/dukko-spotify-like.json
+++ b/plugins/dukko-spotify-like.json
@@ -1,0 +1,13 @@
+{
+    "id": "spotifyLike",
+    "name": "Spotify Like",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Dukko/dms-spotify-like",
+    "author": "Dukko",
+    "description": "DankDash-style media popout with a heart button to save/unsave the current track to your Spotify Library",
+    "dependencies": ["python3", "curl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Dukko/dms-spotify-like/main/docs/screenshot.png"
+}


### PR DESCRIPTION
## Summary
- Adds the `Spotify Like` plugin to the registry: a DankDash-style media popout with a heart button to save/unsave the current track to your Spotify Library.
- Plugin repo: https://github.com/Dukko/dms-spotify-like

## Checklist
- [x] Plugin manifest added at `plugins/dukko-spotify-like.json`
- [x] Plugin repo is public and contains a `plugin.json`, `README.md`, and `LICENSE`
- [x] Screenshot included in plugin repo docs