### PR TITLE
Add Dank Geary Mail plugin

### DIFF
--- a/plugins/schneik80-dms-geary-mail.json
+++ b/plugins/schneik80-dms-geary-mail.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankGearyMail",
+    "name": "Dank Geary Mail",
+    "capabilities": ["dankbar-widget"],
+    "category": "productivity",
+    "repo": "https://github.com/schneik80/dms-geary-mail",
+    "path": "plugin",
+    "author": "schneik80",
+    "description": "Unread mail counts for every account configured in Geary. Reads Geary's local database, so no IMAP credentials are needed. Bar badge plus a popout with per-account counts and recent unread messages.",
+    "dependencies": ["python3", "geary"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/schneik80/dms-geary-mail/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds **Dank Geary Mail** — a bar widget showing unread mail counts for every account configured in [Geary](https://wiki.gnome.org/Apps/Geary).

Rather than asking for IMAP credentials, it reads the per-account SQLite databases Geary already keeps in sync (Flatpak or native install), so there is nothing to configure beyond having Geary set up. Bar badge with total (or per-account) unread; popout with per-account counts and the most recent unread messages; right-click launches Geary.

- Repo: https://github.com/schneik80/dms-geary-mail (plugin lives in `plugin/`, hence `path`)
- Dependencies: `python3` (stdlib only), Geary
- `.github/generate.py --validate` passes; `id`/`name` match the repo's `plugin.json`; screenshot URL returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jz19td7yDBjhE4ZvxAbXP8