### PR TITLE
[plugin] Add virtualKeyboard

### DIFF
--- a/plugins/sitolam-virtualkeyboard.json
+++ b/plugins/sitolam-virtualkeyboard.json
@@ -1,0 +1,14 @@
+{
+  "id": "virtualKeyboard",
+  "name": "Virtual Keyboard",
+  "capabilities": ["daemon", "ipc", "dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/sitolam/dms-plugins",
+  "path": "plugins/virtualkeyboard",
+  "author": "sitolam",
+  "description": "On-screen keyboard overlay, toggled by IPC or an optional DankBar pill",
+  "dependencies": ["ydotool"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/sitolam/dms-plugins/main/plugins/virtualkeyboard/screenshots/docked.png"
+}


### PR DESCRIPTION
Adds `plugins/sitolam-virtualkeyboard.json`.

virtualKeyboard is an on-screen keyboard for DMS. It docks along the bottom of the screen as a layershell overlay (exclusive zone 0, so nothing reflows), and the pin button swaps it for an ordinary floating window that the compositor manages — draggable, stackable, closable from its titlebar. A keyboard icon in DankBar is optional and toggles it, which is the way in on a touchscreen where a keybind has nothing to press; otherwise `dms ipc call virtualKeyboard toggle` binds to whatever key you like.

Keys are injected as raw Linux input events through `ydotool` rather than as Wayland text input, so it types into terminals, games and password prompts the same way a physical keyboard does — `Ctrl` / `Alt` combos included. Modifiers latch: `Shift` arms for one key, a second tap caps-locks, and the rest stay held until pressed again or the keyboard closes. The only dependency is `ydotool` with its `ydotoold` daemon running; the plugin ships a startup check that says so plainly when it is missing.

It lives in the same monorepo as my dankMenu (#784) and MouthGuard (#792) entries, so the listing uses `path` to point at `plugins/virtualkeyboard`. `id` and `name` match that directory's `plugin.json` exactly (`virtualKeyboard` / `Virtual Keyboard`).

The design is [end-4](https://github.com/end-4)'s, from [dots-hyprland](https://github.com/end-4/dots-hyprland) — credited in both the plugin's README and the repo root.
