### PR TITLE
[plugin] Update desc dcalTasks: mention /list task-list selection

### DIFF
--- a/plugins/antonykor-dcal-tasks.json
+++ b/plugins/antonykor-dcal-tasks.json
@@ -5,7 +5,7 @@
     "category": "productivity",
     "repo": "https://github.com/AntonyKor/dcal-tasks-launcher",
     "author": "AntonyKor",
-    "description": "List, search, create, and complete dcal tasks from the launcher, with natural language due dates.",
+    "description": "List, search, create, and complete dcal tasks from the launcher, with natural language due dates and /list task-list selection.",
     "dependencies": ["dcal"],
     "compositors": ["any"],
     "distro": ["any"],


### PR DESCRIPTION
Description-only update to `plugins/antonykor-dcal-tasks.json`. No other fields change.

**Plugin**: [Dcal Tasks](https://github.com/AntonyKor/dcal-tasks-launcher) — a launcher plugin that lists, searches, creates and completes [dcal](https://github.com/AvengeMedia/dankcalendar) tasks from the DMS launcher.

[v0.2.0](https://github.com/AntonyKor/dcal-tasks-launcher/releases/tag/v0.2.0) added a `/<list>` token to the query: `; buy milk /personal` creates the task in Personal, and `; /personal` narrows the launcher to that list. It composes with the existing natural language due dates (`; milk /personal tomorrow at 6PM`), which is all the old description advertised.

Validated with `python3 .github/generate.py --validate` → `Validation successful!`