### PR TITLE
[plugin] Add Browser Tabs Launcher

### DIFF
--- a/plugins/kmf-tabs-launcher.json
+++ b/plugins/kmf-tabs-launcher.json
@@ -1,0 +1,14 @@
+{
+    "id": "tabsLauncher",
+    "name": "Browser Tabs Launcher",
+    "capabilities": ["launcher"],
+    "category": "utilities",
+    "repo": "https://github.com/kmf/dms-tabs-launcher",
+    "author": "kmf",
+    "description": "List and activate open browser tabs from the DMS launcher via tabctl",
+    "dependencies": ["tabctl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/kmf/dms-tabs-launcher/blob/main/screenshot.png?raw=true",
+    "requires_dms": ">=1.4.0"
+}


### PR DESCRIPTION
Adds [dms-tabs-launcher](https://github.com/kmf/dms-tabs-launcher) to the registry.

A DMS launcher plugin that lists open browser tabs (Firefox, Chrome, Brave, Brave Origin, and other tabctl-connected browsers) and activates the selected tab, including window focus.

- **id:** `tabsLauncher` (matches `plugin.json`)
- **capability:** `launcher`
- **dependency:** [tabctl](https://github.com/slastra/tabctl)
- **requires_dms:** `>=1.4.0`

Sister plugin to [obsidian-search](https://github.com/kmf/dms-obsidian-search) (already in the registry). Local `generate.py --validate` and `validate_links.py` both pass.