### PR TITLE
[plugin] Add GameChat-Mix

### DIFF
--- a/plugins/shochraos-game-chat-mix.json
+++ b/plugins/shochraos-game-chat-mix.json
@@ -1,0 +1,14 @@
+{
+    "id": "gamechatMix",
+    "name": "Game / Chat Mix",
+    "capabilities": ["dankbar-widget", "daemon", "audio"],
+    "category": "audio",
+    "repo": "https://github.com/Shochraos/game-chat-mix",
+    "path": "dms",
+    "author": "Shochraos",
+    "description": "Balance game audio against Discord/chat audio with a single slider, with the routing daemon built in",
+    "dependencies": ["pactl", "gawk", "flock"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Shochraos/game-chat-mix/main/assets/screenshot.png"
+}

--- a/plugins/shochraos-game-chat-mix.json
+++ b/plugins/shochraos-game-chat-mix.json
@@ -8,7 +8,7 @@
     "author": "Shochraos",
     "description": "Balance game audio against Discord/chat audio with a single slider, with the routing daemon built in",
     "dependencies": ["pactl", "gawk", "flock"],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/Shochraos/game-chat-mix/main/assets/screenshot.png"
 }


### PR DESCRIPTION
Adds gamechat-mix to the registry.

 A DMS composite plugin for the game/chat audio balance on a two-sink PipeWire split: a DankBar pill showing game / chat and a popout slider that moves the mix, game on the left, chat on the right. The slider writes the two node volumes directly, so dragging spawns no process, and the value is read straight off the nodes. The daemon surface optionally supervises gamechat_mix and exposes an IpcHandler, so dms ipc call gamechat game|chat|reset|setMix|status works from compositor keybinds.

 ```
id: gamechatMix (matches dms/plugin.json)
type: composite
capabilities: dankbar-widget, daemon, audio
category: audio
dependency: gamechat_mix (from the same repo, systemd unit or PATH)
requires_dms: >=1.5.0
path: dms (monorepo)
 ```