### PR TITLE
[plugin] Add Bar Dropdown

### DIFF
--- a/plugins/sitolam-bardropdown.json
+++ b/plugins/sitolam-bardropdown.json
@@ -1,0 +1,14 @@
+{
+  "id": "barDropdown",
+  "name": "Bar Dropdown",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/sitolam/dms-plugins",
+  "path": "plugins/bardropdown",
+  "author": "sitolam",
+  "description": "One bar button that drops a panel of real bar widgets below the bar, for side sections with no room to expand along it",
+  "dependencies": [],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/sitolam/dms-plugins/main/plugins/bardropdown/screenshots/panel.png"
+}


### PR DESCRIPTION
## Bar Dropdown (`barDropdown`)

One bar button that drops a panel of **real bar widgets** below the bar. Click it and the members appear in a popout hanging under the button — each one a live widget with its own working popout — and click again to close.

![the barDropdown panel open below the bar](https://raw.githubusercontent.com/sitolam/dms-plugins/main/plugins/bardropdown/screenshots/panel.png)

### Why another widget collapser

There are already two plugins that collapse bar widgets — `hiddenBar` and `widgetGroup` — and both hide the widgets in place and reveal them inline along the bar. In a **side section** that reveal has nowhere to go.

`DankBarContent.qml` anchors the three sections independently: left to `parent.left`, right to `parent.right`, centre to `parent.horizontalCenter`. They do not share a layout, so a right-section widget that grows wider only pushes its own section's left edge further left, into the empty middle of the bar. The centre widgets stay pinned to the screen centre and never move — and because the centre section paints after the right one, an expansion wide enough to reach them ends up *underneath* the clock.

This plugin does not expand along the bar at all. Setting `popoutContent` on a `PluginComponent` gets a `DankPopout` anchored under the trigger and painted above the windows below, so nothing on the bar moves and nothing overlaps.

### Notes

- Members can be third-party `widget` plugins or DMS built-ins (`systemTray`, `clock`, `music`, …); a plugin variant is `pluginId:variantId`.
- A member must not also be placed on the bar, or it renders twice.
- Monorepo entry: `path` is `plugins/bardropdown`.
- No dependencies beyond DMS.

### Credit

`DropdownMember.qml` is `GroupMember.qml` from [rdannenbring/widget-group](https://github.com/rdannenbring/widget-group) (MIT, licence kept in the plugin directory as `LICENSE.widget-group` and credited in its README), changed only in its header, type name and log tag. Its property injection mirrors what `WidgetHost.qml` sets on a bar widget, and reimplementing it would have been a worse copy of the same thing.

### Validation

`python3 .github/generate.py --validate` → `Validation successful!`
`id` and `name` match `plugins/bardropdown/plugin.json`; repo, path and screenshot URLs all return 200.
