### PR TITLE
[plugin] Add Proxy Traffic

### DIFF
--- a/plugins/lemon-mon-254-proxy-traffic.json
+++ b/plugins/lemon-mon-254-proxy-traffic.json
@@ -7,7 +7,7 @@
     "author": "lemonmon",
     "description": "Realtime throughput and cumulative traffic of your local proxy, tracked via nftables",
     "dependencies": ["nft"],
-    "compositors": ["niri", "hyprland"],
+    "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/Lemon-mon-254/dms-proxy-traffic/main/screenshots/1.png"
 }

--- a/plugins/lemon-mon-254-proxy-traffic.json
+++ b/plugins/lemon-mon-254-proxy-traffic.json
@@ -1,0 +1,13 @@
+{
+    "id": "proxyTraffic",
+    "name": "Proxy Traffic",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/Lemon-mon-254/dms-proxy-traffic",
+    "author": "lemonmon",
+    "description": "Realtime throughput and cumulative traffic of your local proxy, tracked via nftables",
+    "dependencies": ["nft"],
+    "compositors": ["niri", "hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Lemon-mon-254/dms-proxy-traffic/main/screenshots/1.png"
+}


### PR DESCRIPTION
### Proxy Traffic

A DankBar widget that monitors real-time throughput and cumulative traffic of your local proxy via nftables counters.

- **Features**: live ↓/↑ rates on the bar, popout with cumulative traffic and traffic destinations (target domains & processes), configurable display and refresh interval, persistent (survives reboot) nftables rules via a one-command installer.
- **Screenshot**: https://raw.githubusercontent.com/Lemon-mon-254/dms-proxy-traffic/main/screenshots/1.png
- **Repo**: https://github.com/Lemon-mon-254/dms-proxy-traffic

All registry metadata fields validated with `generate.py --validate`.