### PR TITLE
[plugin] Add CLIProxyAPI Quota

### DIFF
--- a/plugins/spyrospsarras-dms-cliproxy-quota.json
+++ b/plugins/spyrospsarras-dms-cliproxy-quota.json
@@ -1,0 +1,13 @@
+{
+    "id": "cliproxyQuota",
+    "name": "CLIProxyAPI Quota",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/SpyrosPsarras/dms-cliproxy-quota",
+    "author": "Spyros Psarras",
+    "description": "Remaining provider quota from a CLIProxyAPI server: per-provider rings, pace, reset countdowns and daily activity. Requires the pi-bridge plugin on the server.",
+    "dependencies": ["curl", "jq"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/SpyrosPsarras/dms-cliproxy-quota/main/screenshot.png"
+}


### PR DESCRIPTION
Adds **CLIProxyAPI Quota** (`cliproxyQuota`) — a dankbar widget showing remaining provider quota from a [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) server: per-provider carousel with brand-logo tabs, remaining-quota rings, pace against the window, reset countdowns, per-account health, and a requests-per-day activity strip.

Requires the [pi-bridge](https://github.com/abix5/pi-cliproxyapi-bridge) plugin on the CLIProxyAPI server (stated in the manifest description and in the README's first section — the widget explains this at runtime when the route is absent).

Repo: https://github.com/SpyrosPsarras/dms-cliproxy-quota — MIT, offline test suite (shell seam tests + static QML checks) running in CI. `id`/`name` match the repo's plugin.json; `generate.py --validate` passes locally.