### PR TITLE
[plugin] Add LyricsEmbed

### DIFF
--- a/plugins/lemon-mon-254-lyricsembed.json
+++ b/plugins/lemon-mon-254-lyricsembed.json
@@ -1,0 +1,13 @@
+{
+  "id": "lyricsEmbed",
+  "name": "LyricsEmbed",
+  "capabilities": ["dankbar-widget"],
+  "category": "utilities",
+  "repo": "https://github.com/Lemon-mon-254/dms-plugin-Lyrics",
+  "author": "lemonmon",
+  "description": "An embedded-lyrics-first synced lyrics plugin for DMS: embedded LRC extraction, multi-source lyrics, bilingual split view, per-song offset tuning, zh/en interface.",
+  "dependencies": ["ffprobe"],
+  "compositors": ["any"],
+  "distro": ["any"],
+  "screenshot": "https://raw.githubusercontent.com/Lemon-mon-254/dms-plugin-Lyrics/main/docs/screenshot.png"
+}


### PR DESCRIPTION
## What does this plugin do?
An embedded-lyrics-first synced lyrics plugin for DankMaterialShell: extracts LRC from audio files, fetches from multiple online sources (LRCLib/NetEase/custom API), shows bilingual split view, per-song offset tuning, zh/en interface.

## Checklist
- [x] Valid JSON for the plugin's `id`, `name`, `capabilities`, `category`, `repo`, `author`, `description`, `dependencies`, `compositors`, `distro`
- [x] All URLs verified accessible (repo + screenshot)
- [x] Screenshot included
- [x] `id` is camelCase and matches the plugin's `plugin.json`
- [x] `generate.py --validate` passes locally