### PR TITLE
[plugin] Update desc shellyUpdater

### DIFF
--- a/plugins/rdannenbring-shelly-updater.json
+++ b/plugins/rdannenbring-shelly-updater.json
@@ -6,7 +6,7 @@
   "repo": "https://github.com/rdannenbring/dms-shelly-updater",
   "screenshot": "https://raw.githubusercontent.com/rdannenbring/dms-shelly-updater/main/preview/updates.png",
   "author": "rdannenbring",
-  "description": "Comprehensive system update widget backed by the Shelly (ALPM) CLI — pacman, AUR, Flatpak and AppImage in one DankBar pill with a detailed updates view, action menu, and control-center panel. Requires Shelly v3+.",
+  "description": "Comprehensive system update widget backed by the Shelly (ALPM) CLI — pacman, AUR, Flatpak and AppImage in one DankBar pill with a detailed updates view, action menu, and control-center panel. Also counts DMS plugin and device firmware updates, plus any other tool you describe in a config file (mise and Rust toolchains ship as worked examples). Requires Shelly v3+.",
   "dependencies": ["shelly>=3"],
   "compositors": ["any"],
   "distro": ["arch"]


### PR DESCRIPTION
Description-only update to `plugins/rdannenbring-shelly-updater.json`. No new plugin, no schema changes — the entry carries no version field, so v2.2.0 itself published when it merged to the plugin repo's `main`.

Shelly Updater now also counts sources Shelly doesn't manage:

- **DMS plugins** and **device firmware**, built in
- **anything else you describe in a config file** — a command that lists what's outdated, how to read its output, how to apply an update. mise and Rust toolchains ship as worked examples

The old description mentioned only pacman/AUR/Flatpak/AppImage, which now undersells it on the plugins screen.

Verified before opening: JSON parses, all required fields present, `id` and `name` still match the repo's `plugin.json`, and `capabilities` left as `control-center` to match the convention used across the rest of the registry.

Upstream: https://github.com/rdannenbring/dms-shelly-updater

🤖 Generated with [Claude Code](https://claude.com/claude-code)