### PR TITLE
[plugin] Update desc CLIProxyAPI Quota

### DIFF
--- a/plugins/spyrospsarras-dms-cliproxy-quota.json
+++ b/plugins/spyrospsarras-dms-cliproxy-quota.json
@@ -1,13 +1,22 @@
 {
     "id": "cliproxyQuota",
     "name": "CLIProxyAPI Quota",
-    "capabilities": ["dankbar-widget"],
+    "capabilities": [
+        "dankbar-widget"
+    ],
     "category": "monitoring",
     "repo": "https://github.com/SpyrosPsarras/dms-cliproxy-quota",
     "author": "Spyros Psarras",
-    "description": "Remaining provider quota from a CLIProxyAPI server: per-provider rings, pace, reset countdowns and daily activity. Requires the pi-bridge plugin on the server.",
-    "dependencies": ["curl", "jq"],
-    "compositors": ["any"],
-    "distro": ["any"],
+    "description": "Remaining AI provider quota (Claude, Codex, Copilot and more) from a CLIProxyAPI server: per-provider rings, pace, reset countdowns and daily activity. Requires the pi-bridge plugin on the server.",
+    "dependencies": [
+        "curl",
+        "jq"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
     "screenshot": "https://raw.githubusercontent.com/SpyrosPsarras/dms-cliproxy-quota/main/screenshot.png"
 }


### PR DESCRIPTION
Description-only change for cliproxyQuota: people find this plugin family by searching "AI", "claude" or "codex" — none of those words appeared in the description, so search missed it. Now it names the providers it typically fronts (examples, not a hard list — the widget renders whatever providers the proxy reports).