### PR TITLE
[plugin] Add Dank Album Widget

### DIFF
--- a/plugins/kmf-dank-album-widget.json
+++ b/plugins/kmf-dank-album-widget.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankAlbumWidget",
+    "name": "Dank Album Widget",
+    "capabilities": ["desktop-widget"],
+    "category": "media",
+    "repo": "https://github.com/kmf/dank-album-widget",
+    "author": "kmf",
+    "description": "Square album-cover desktop widget with Material play, previous, and next over MPRIS",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/kmf/dank-album-widget/main/screenshot.jpg",
+    "requires_dms": ">=1.2.0"
+}


### PR DESCRIPTION
## Summary
Adds **Dank Album Widget** (`dankAlbumWidget`) to the registry.

Square desktop album-cover widget for DankMaterialShell. It talks to the same MPRIS stack as DankDash media and overlays Material previous / play-pause / next on the cover. Scroll on the widget changes system volume.

- **Repo:** https://github.com/kmf/dank-album-widget
- **id / name:** match `plugin.json` (`dankAlbumWidget` / `Dank Album Widget`)
- **capability:** `desktop-widget`
- **category:** `media`
- **requires_dms:** `>=1.2.0`
- **screenshot:** https://raw.githubusercontent.com/kmf/dank-album-widget/main/screenshot.jpg

## Test plan
- [x] `id` is camelCase and matches the plugin repo `plugin.json`
- [x] `name` matches the plugin repo `plugin.json`
- [x] repo and screenshot URLs return 200
- [ ] CI `validate-pr` / link checks pass