### PR TITLE
[plugin] Add Shazam

### DIFF
--- a/plugins/awesomemi-shazam.json
+++ b/plugins/awesomemi-shazam.json
@@ -1,0 +1,23 @@
+{
+    "id": "shazam",
+    "name": "Shazam",
+    "capabilities": [
+        "dankbar-widget",
+        "daemon"
+    ],
+    "category": "media",
+    "repo": "https://github.com/AwesomeMi/dms-shazam",
+    "author": "AwesomeMi",
+    "description": "Identify the song playing around you straight from the DankBar, powered by SongRec",
+    "dependencies": [
+        "songrec",
+        "libpulse"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/AwesomeMi/dms-shazam/main/screenshot.png"
+}


### PR DESCRIPTION
Adds [dms-shazam](https://github.com/AwesomeMi/dms-shazam) — song recognition in the DankBar, powered by [SongRec](https://github.com/marin-m/SongRec).

Left click the pill to open the panel and start listening, right click to identify without opening anything, or bind a key to `dms ipc call shazam identify`. A match shows cover art, title, artist, album and year, one chip per streaming service Shazam returns for the track (Spotify, YouTube Music, Deezer, Apple Music), copy buttons for the title and for the full details including ISRC, and a source switch. Recent matches are kept in the plugin state file.

A note on the dependency list: the plugin does not use SongRec's own live capture. Against a PipeWire monitor source it samples for minutes without ever matching audio that it recognizes instantly from a file — verified side by side, same source, same minute. So the plugin records a 13 second chunk with `parecord` and hands the file to `songrec recognize --json`, repeating until the listening budget runs out. That is where the `libpulse` dependency comes from (`parecord` and `pactl`); by default it resolves `pactl get-default-sink` at each run, so it follows the output device.

Composite plugin: the recognition lives in a daemon surface so a multi-monitor setup shares one process and one result across every bar.

`python3 .github/generate.py --validate` passes; the repo and the screenshot URL both return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui6BoZPDowVQPpqRUi85NF