### PR TITLE
[plugin] Add Radio Atlas Lite

### DIFF
--- a/plugins/alamin147-radio-atlas.json
+++ b/plugins/alamin147-radio-atlas.json
@@ -1,0 +1,13 @@
+{
+    "id": "radioAtlasLite",
+    "name": "Radio Atlas Lite",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/alamin147/RadioAtlasLite",
+    "author": "Al Amin",
+    "description": "Launch a lightweight interactive world radio atlas from DankBar.",
+    "dependencies": ["mpv"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/alamin147/RadioAtlasLite/blob/main/main/docs/screenshot.png"
+}


### PR DESCRIPTION
## Summary

Adds Radio Atlas Lite to the DMS plugin registry.

Radio Atlas Lite is a lightweight DankBar launcher for an interactive world radio app. It uses Quickshell and `mpv` only, with no additional runtime dependencies beyond `mpv`.

## Plugin details

- Type: DankBar widget
- Category: Utilities
- Dependency: `mpv`
- Compositor support: Any
- Distro support: Any

The plugin is a lightweight DMS adaptation inspired by the original Radio Atlas project by Akshar Patel:
https://github.com/AksharP5/omarchy-radio-atlas