### PR TITLE
[plugin] Add herdr Agent Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2367,6 +2367,26 @@ Shows central and peripheral battery levels for a ZMK split keyboard
 
 
 
+#### [herdr Agent Monitor](https://github.com/Mor-dev/herdr-agent-monitor)
+
+Shows live agent status (working/idle/blocked/done) across herdr panes in the bar, click one to focus its pane
+
+
+
+- id: herdrAgentMonitor
+- name: herdr Agent Monitor
+- author: Mor-dev
+- compositors: any
+- capabilities: dankbar-widget
+- dependencies: herdr
+- distro: any
+
+
+
+
+
+
+
 ---
 
 

--- a/plugins/mor-dev-herdr-agent-monitor.json
+++ b/plugins/mor-dev-herdr-agent-monitor.json
@@ -1,0 +1,21 @@
+{
+    "id": "herdrAgentMonitor",
+    "name": "herdr Agent Monitor",
+    "capabilities": [
+        "dankbar-widget"
+    ],
+    "category": "monitoring",
+    "repo": "https://github.com/Mor-dev/herdr-agent-monitor",
+    "author": "Mor-dev",
+    "description": "Shows live agent status (working/idle/blocked/done) across herdr panes in the bar, click one to focus its pane",
+    "dependencies": [
+        "herdr"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/Mor-dev/herdr-agent-monitor/master/assets/popout.png"
+}


### PR DESCRIPTION
## Summary
Adds [herdr Agent Monitor](https://github.com/Mor-dev/herdr-agent-monitor), a bar widget showing
live agent status (working/idle/blocked/done) across [herdr](https://herdr.dev) panes, with a
popout listing each agent's title/cwd/status and click-to-focus.

## Checklist
- [x] `python3 .github/generate.py --validate` passes
- [x] `python3 .github/validate_links.py` passes for this entry (2 unrelated pre-existing entries
      fail due to dead upstream repos, not touched by this PR)
- [x] `id`/`name` match the repository's `plugin.json`