### PR TITLE
[plugin] Add Wallpaper by Workspace

### DIFF
--- a/plugins/3dtreedee-wallpaper-by-workspace.json
+++ b/plugins/3dtreedee-wallpaper-by-workspace.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/3DTreeDee/wallpaperByWorkspace",
     "author": "Jairo Sierra",
     "description": "Sets a different wallpaper per niri workspace, with fixed or alternate mode, optional periodic rotation, and a \"show desktop\" transition.",
-    "dependencies": ["niri"],
+    "dependencies": [],
     "compositors": ["niri"],
     "distro": ["any"],
     "screenshot": "https://github.com/3DTreeDee/wallpaperByWorkspace/raw/main/screenshot.png",

--- a/plugins/3dtreedee-wallpaper-by-workspace.json
+++ b/plugins/3dtreedee-wallpaper-by-workspace.json
@@ -1,0 +1,14 @@
+{
+    "id": "wallpaperByWorkspace",
+    "name": "Wallpaper by Workspace",
+    "capabilities": ["wallpaper"],
+    "category": "appearance",
+    "repo": "https://github.com/3DTreeDee/wallpaperByWorkspace",
+    "author": "Jairo Sierra",
+    "description": "Sets a different wallpaper per niri workspace, with fixed or alternate mode, optional periodic rotation, and a \"show desktop\" transition.",
+    "dependencies": ["niri"],
+    "compositors": ["niri"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/3DTreeDee/wallpaperByWorkspace/raw/main/screenshot.png",
+    "requires_dms": ">=1.2.0"
+}


### PR DESCRIPTION
## Description
Adds the **Wallpaper by Workspace** plugin (daemon) to the plugin registry.

A DankMaterialShell daemon plugin that sets a different wallpaper per workspace on the **niri** compositor (fixed/alternate mode, optional periodic rotation, and a "show desktop" transition while the theme regenerates).

## Plugin info
- **id**: `wallpaperByWorkspace`
- **name**: Wallpaper by Workspace
- **capabilities**: `["wallpaper"]`
- **category**: appearance
- **compositors**: niri
- **requires DMS**: >=1.2.0

## Validation
- `python3 .github/generate.py --validate` → OK
- `python3 .github/validate_links.py` (changed files) → OK