### PR TITLE
[plugin] Add OpenRGB Theme Sync

### DIFF
--- a/plugins/3dtreedee-openrgb-theme-sync.json
+++ b/plugins/3dtreedee-openrgb-theme-sync.json
@@ -1,0 +1,21 @@
+{
+    "id": "openrgbThemeSync",
+    "name": "OpenRGB Theme Sync",
+    "capabilities": [
+        "daemon"
+    ],
+    "category": "appearance",
+    "repo": "https://github.com/3DTreeDee/openrgb-theme-sync",
+    "author": "3DTreeDee",
+    "description": "Syncs your DankMaterialShell theme colors with RGB hardware via OpenRGB. Watches theme color changes and applies the configured color to connected devices, with optional per-device modes.",
+    "dependencies": [
+        "openrgb"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/3DTreeDee/openrgb-theme-sync/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Background daemon that syncs DankMaterialShell theme colors to OpenRGB hardware via the SDK server.

- Watches theme color changes (matugen) and applies the configured DMS color globally plus optional per-device fixed modes (addressed by name, stable across rescans)
- Serial command queue with coalescing, exponential-backoff retries, SDK watchdog with auto-relaunch, single-toast failure notice
- Validated locally: `generate.py --validate` passes; repo and screenshot URLs verified reachable; `id`/`name` match the plugin repo's `plugin.json`

Plugin repo: https://github.com/3DTreeDee/openrgb-theme-sync