### PR TITLE
theme: update Jozi City Nights to 1.1.1 (WCAG AA)

### DIFF
--- a/themes/jozi-city/theme.json
+++ b/themes/jozi-city/theme.json
@@ -1,15 +1,15 @@
 {
   "id": "joziCityNights",
   "name": "Jozi City Nights",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "author": "kmf",
-  "description": "A neon-lit colorscheme — cool blue-grey backgrounds with cyberpunk-bright accents",
+  "description": "A neon-lit colorscheme \u2014 cool blue-grey backgrounds with cyberpunk-bright accents",
   "dark": {
     "surfaceText": "#a9b1d6",
     "surfaceVariantText": "#c0caf5",
     "backgroundText": "#a9b1d6",
-    "outline": "#8089b3",
-    "error": "#f92aad",
+    "outline": "#868eb7",
+    "error": "#f935b1",
     "warning": "#ff9e64",
     "info": "#7aa2f7"
   },
@@ -17,17 +17,26 @@
     "surfaceText": "#343b58",
     "surfaceVariantText": "#1f2335",
     "backgroundText": "#343b58",
-    "outline": "#6172af",
-    "error": "#d6197a",
-    "warning": "#d9580a",
-    "info": "#4f46e5"
+    "outline": "#3f4d7d",
+    "error": "#a0135b",
+    "warning": "#8f3a06",
+    "info": "#3b30e2"
   },
   "variants": {
     "type": "multi",
     "defaults": {
-      "dark": { "flavor": "nights", "accent": "pink" },
-      "light": { "flavor": "morning", "accent": "pink" },
-      "midnight": { "flavor": "midnight", "accent": "pink" }
+      "dark": {
+        "flavor": "nights",
+        "accent": "pink"
+      },
+      "light": {
+        "flavor": "morning",
+        "accent": "pink"
+      },
+      "midnight": {
+        "flavor": "midnight",
+        "accent": "pink"
+      }
     },
     "flavors": [
       {
@@ -37,11 +46,11 @@
           "surface": "#1f2335",
           "surfaceVariant": "#24283b",
           "background": "#1b1e2e",
-          "surfaceContainerLowest": "#1d2133",
-          "surfaceContainerLow": "#1d2133",
           "surfaceContainer": "#1f2335",
           "surfaceContainerHigh": "#24283b",
-          "surfaceContainerHighest": "#3b4261"
+          "surfaceContainerHighest": "#3b4261",
+          "surfaceContainerLow": "#1d2133",
+          "surfaceContainerLowest": "#1d2133"
         }
       },
       {
@@ -51,11 +60,11 @@
           "surface": "#16161e",
           "surfaceVariant": "#1a1b26",
           "background": "#101014",
-          "surfaceContainerLowest": "#14141b",
-          "surfaceContainerLow": "#14141b",
           "surfaceContainer": "#16161e",
           "surfaceContainerHigh": "#1a1b26",
-          "surfaceContainerHighest": "#232433"
+          "surfaceContainerHighest": "#232433",
+          "surfaceContainerLow": "#14141b",
+          "surfaceContainerLowest": "#14141b"
         }
       },
       {
@@ -65,11 +74,11 @@
           "surface": "#c8c9d1",
           "surfaceVariant": "#bfc1cc",
           "background": "#d5d6db",
-          "surfaceContainerLowest": "#ccccd3",
-          "surfaceContainerLow": "#ccccd3",
           "surfaceContainer": "#c8c9d1",
           "surfaceContainerHigh": "#bfc1cc",
-          "surfaceContainerHighest": "#b0b3be"
+          "surfaceContainerHighest": "#b0b3be",
+          "surfaceContainerLow": "#ccccd3",
+          "surfaceContainerLowest": "#ccccd3"
         }
       }
     ],
@@ -77,58 +86,202 @@
       {
         "id": "pink",
         "name": "Pink",
-        "nights": { "primary": "#f92aad", "secondary": "#73daca", "primaryText": "#1b1e2e", "primaryContainer": "#4d1a3c", "surfaceTint": "#2d1628" },
-        "midnight": { "primary": "#f92aad", "secondary": "#73daca", "primaryText": "#101014", "primaryContainer": "#2e1024", "surfaceTint": "#1a0d18" },
-        "morning": { "primary": "#d6197a", "secondary": "#0d9488", "primaryText": "#d5d6db", "primaryContainer": "#e8c2d4", "surfaceTint": "#e8c2d4" }
+        "nights": {
+          "primary": "#f935b1",
+          "secondary": "#73daca",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#4d1a3c",
+          "surfaceTint": "#2d1628"
+        },
+        "midnight": {
+          "primary": "#f92aad",
+          "secondary": "#73daca",
+          "primaryText": "#101014",
+          "primaryContainer": "#2e1024",
+          "surfaceTint": "#1a0d18"
+        },
+        "morning": {
+          "primary": "#a0135b",
+          "secondary": "#115e59",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#e8c2d4",
+          "surfaceTint": "#e8c2d4"
+        }
       },
       {
         "id": "blue",
         "name": "Blue",
-        "nights": { "primary": "#7aa2f7", "secondary": "#ff9e64", "primaryText": "#1b1e2e", "primaryContainer": "#2a3a5c", "surfaceTint": "#1e2436" },
-        "midnight": { "primary": "#7aa2f7", "secondary": "#ff9e64", "primaryText": "#101014", "primaryContainer": "#192238", "surfaceTint": "#121520" },
-        "morning": { "primary": "#4f46e5", "secondary": "#d9580a", "primaryText": "#d5d6db", "primaryContainer": "#c8c5e8", "surfaceTint": "#c8c5e8" }
+        "nights": {
+          "primary": "#7aa2f7",
+          "secondary": "#ff9e64",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#2a3a5c",
+          "surfaceTint": "#1e2436"
+        },
+        "midnight": {
+          "primary": "#7aa2f7",
+          "secondary": "#ff9e64",
+          "primaryText": "#101014",
+          "primaryContainer": "#192238",
+          "surfaceTint": "#121520"
+        },
+        "morning": {
+          "primary": "#3b30e2",
+          "secondary": "#8f3a06",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#c8c5e8",
+          "surfaceTint": "#c8c5e8"
+        }
       },
       {
         "id": "purple",
         "name": "Purple",
-        "nights": { "primary": "#b141f1", "secondary": "#e0b401", "primaryText": "#1b1e2e", "primaryContainer": "#3e1e54", "surfaceTint": "#281730" },
-        "midnight": { "primary": "#b141f1", "secondary": "#e0b401", "primaryText": "#101014", "primaryContainer": "#251234", "surfaceTint": "#180e1d" },
-        "morning": { "primary": "#7928a8", "secondary": "#c49000", "primaryText": "#d5d6db", "primaryContainer": "#d5c2e0", "surfaceTint": "#d5c2e0" }
+        "nights": {
+          "primary": "#c064f4",
+          "secondary": "#e0b401",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#3e1e54",
+          "surfaceTint": "#281730"
+        },
+        "midnight": {
+          "primary": "#bb58f3",
+          "secondary": "#e0b401",
+          "primaryText": "#101014",
+          "primaryContainer": "#251234",
+          "surfaceTint": "#180e1d"
+        },
+        "morning": {
+          "primary": "#7928a8",
+          "secondary": "#6a4f00",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#d5c2e0",
+          "surfaceTint": "#d5c2e0"
+        }
       },
       {
         "id": "green",
         "name": "Green",
-        "nights": { "primary": "#54e484", "secondary": "#b141f1", "primaryText": "#1b1e2e", "primaryContainer": "#1e4833", "surfaceTint": "#182b22" },
-        "midnight": { "primary": "#54e484", "secondary": "#b141f1", "primaryText": "#101014", "primaryContainer": "#122b1f", "surfaceTint": "#0e1a14" },
-        "morning": { "primary": "#16864a", "secondary": "#7928a8", "primaryText": "#d5d6db", "primaryContainer": "#c2dccb", "surfaceTint": "#c2dccb" }
+        "nights": {
+          "primary": "#54e484",
+          "secondary": "#c064f4",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#1e4833",
+          "surfaceTint": "#182b22"
+        },
+        "midnight": {
+          "primary": "#54e484",
+          "secondary": "#bb58f3",
+          "primaryText": "#101014",
+          "primaryContainer": "#122b1f",
+          "surfaceTint": "#0e1a14"
+        },
+        "morning": {
+          "primary": "#156031",
+          "secondary": "#7928a8",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#c2dccb",
+          "surfaceTint": "#c2dccb"
+        }
       },
       {
         "id": "yellow",
         "name": "Yellow",
-        "nights": { "primary": "#e0b401", "secondary": "#7aa2f7", "primaryText": "#1b1e2e", "primaryContainer": "#4a3c10", "surfaceTint": "#2a2413" },
-        "midnight": { "primary": "#e0b401", "secondary": "#7aa2f7", "primaryText": "#101014", "primaryContainer": "#2c240a", "surfaceTint": "#19160b" },
-        "morning": { "primary": "#c49000", "secondary": "#4f46e5", "primaryText": "#d5d6db", "primaryContainer": "#ddd5be", "surfaceTint": "#ddd5be" }
+        "nights": {
+          "primary": "#e0b401",
+          "secondary": "#7aa2f7",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#4a3c10",
+          "surfaceTint": "#2a2413"
+        },
+        "midnight": {
+          "primary": "#e0b401",
+          "secondary": "#7aa2f7",
+          "primaryText": "#101014",
+          "primaryContainer": "#2c240a",
+          "surfaceTint": "#19160b"
+        },
+        "morning": {
+          "primary": "#6a4f00",
+          "secondary": "#3b30e2",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#ddd5be",
+          "surfaceTint": "#ddd5be"
+        }
       },
       {
         "id": "orange",
         "name": "Orange",
-        "nights": { "primary": "#ff9e64", "secondary": "#7aa2f7", "primaryText": "#1b1e2e", "primaryContainer": "#553a25", "surfaceTint": "#302419" },
-        "midnight": { "primary": "#ff9e64", "secondary": "#7aa2f7", "primaryText": "#101014", "primaryContainer": "#332316", "surfaceTint": "#1d160f" },
-        "morning": { "primary": "#d9580a", "secondary": "#4f46e5", "primaryText": "#d5d6db", "primaryContainer": "#e4cfc0", "surfaceTint": "#e4cfc0" }
+        "nights": {
+          "primary": "#ff9e64",
+          "secondary": "#7aa2f7",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#553a25",
+          "surfaceTint": "#302419"
+        },
+        "midnight": {
+          "primary": "#ff9e64",
+          "secondary": "#7aa2f7",
+          "primaryText": "#101014",
+          "primaryContainer": "#332316",
+          "surfaceTint": "#1d160f"
+        },
+        "morning": {
+          "primary": "#8f3a06",
+          "secondary": "#3b30e2",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#e4cfc0",
+          "surfaceTint": "#e4cfc0"
+        }
       },
       {
         "id": "cyan",
         "name": "Cyan",
-        "nights": { "primary": "#58c7e0", "secondary": "#f92aad", "primaryText": "#1b1e2e", "primaryContainer": "#1e4450", "surfaceTint": "#162a30" },
-        "midnight": { "primary": "#58c7e0", "secondary": "#f92aad", "primaryText": "#101014", "primaryContainer": "#122930", "surfaceTint": "#0d191d" },
-        "morning": { "primary": "#0891b2", "secondary": "#d6197a", "primaryText": "#d5d6db", "primaryContainer": "#c0d8de", "surfaceTint": "#c0d8de" }
+        "nights": {
+          "primary": "#58c7e0",
+          "secondary": "#f935b1",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#1e4450",
+          "surfaceTint": "#162a30"
+        },
+        "midnight": {
+          "primary": "#58c7e0",
+          "secondary": "#f92aad",
+          "primaryText": "#101014",
+          "primaryContainer": "#122930",
+          "surfaceTint": "#0d191d"
+        },
+        "morning": {
+          "primary": "#145a70",
+          "secondary": "#a0135b",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#c0d8de",
+          "surfaceTint": "#c0d8de"
+        }
       },
       {
         "id": "teal",
         "name": "Teal",
-        "nights": { "primary": "#73daca", "secondary": "#f92aad", "primaryText": "#1b1e2e", "primaryContainer": "#1e4c44", "surfaceTint": "#162c28" },
-        "midnight": { "primary": "#73daca", "secondary": "#f92aad", "primaryText": "#101014", "primaryContainer": "#122d29", "surfaceTint": "#0d1a18" },
-        "morning": { "primary": "#0d9488", "secondary": "#d6197a", "primaryText": "#d5d6db", "primaryContainer": "#c0dcd8", "surfaceTint": "#c0dcd8" }
+        "nights": {
+          "primary": "#73daca",
+          "secondary": "#f935b1",
+          "primaryText": "#1b1e2e",
+          "primaryContainer": "#1e4c44",
+          "surfaceTint": "#162c28"
+        },
+        "midnight": {
+          "primary": "#73daca",
+          "secondary": "#f92aad",
+          "primaryText": "#101014",
+          "primaryContainer": "#122d29",
+          "surfaceTint": "#0d1a18"
+        },
+        "morning": {
+          "primary": "#115e59",
+          "secondary": "#a0135b",
+          "primaryText": "#d5d6db",
+          "primaryContainer": "#c0dcd8",
+          "surfaceTint": "#c0dcd8"
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Bump **Jozi City Nights** from `1.0.0` → `1.1.1`
- Fix DMS WCAG AA failures:
  - restore `surfaceContainerHighest` to elevated surface values (was incorrectly set to border colors, dropping body text to ~2.5:1)
  - nudge accent/status tokens so every nights/midnight/morning × accent combo passes the registry contrast checker
- Result: **AA** across Nights, Midnight, and Morning

Source: https://github.com/kmf/jozi-city-nights

## Test plan
- [x] local theme validation passes
- [x] `python3 .github/check_wcag.py themes/jozi-city` → `AA`
- [ ] CI theme validation passes
- [ ] Preview comment renders nights/midnight/morning accent variants