### PR TITLE
[plugin] Add Aerox 3 Battery

### DIFF
--- a/plugins/crambeary-aerox3-battery.json
+++ b/plugins/crambeary-aerox3-battery.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/Crambeary/dms-aerox3-battery-widget",
     "author": "Crambeary",
     "description": "Shows the battery level of a SteelSeries Aerox 3 Wireless Gen 2 mouse in the bar via rivalcfg, with cascading low-battery notifications",
-    "dependencies": ["python3", "rivalcfg", "notify-send"],
+    "dependencies": ["python3", "hidapi", "notify-send"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://github.com/Crambeary/dms-aerox3-battery-widget/blob/main/screenshot.png"

--- a/plugins/crambeary-aerox3-battery.json
+++ b/plugins/crambeary-aerox3-battery.json
@@ -1,0 +1,13 @@
+{
+    "id": "aerox3Battery",
+    "name": "Aerox 3 Battery",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/Crambeary/dms-aerox3-battery-widget",
+    "author": "Crambeary",
+    "description": "Shows the battery level of a SteelSeries Aerox 3 Wireless Gen 2 mouse in the bar via rivalcfg, with cascading low-battery notifications",
+    "dependencies": ["python3", "rivalcfg", "notify-send"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://github.com/Crambeary/dms-aerox3-battery-widget/blob/main/screenshot.png"
+}

--- a/plugins/crambeary-aerox3-battery.json
+++ b/plugins/crambeary-aerox3-battery.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/Crambeary/dms-aerox3-battery-widget",
     "author": "Crambeary",
     "description": "Shows the battery level of a SteelSeries Aerox 3 Wireless Gen 2 mouse in the bar via rivalcfg, with cascading low-battery notifications",
-    "dependencies": ["python3", "hidapi", "notify-send"],
+    "dependencies": ["python3", "hidapi"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://github.com/Crambeary/dms-aerox3-battery-widget/blob/main/screenshot.png"

--- a/plugins/crambeary-aerox3-battery.json
+++ b/plugins/crambeary-aerox3-battery.json
@@ -9,5 +9,5 @@
     "dependencies": ["python3", "hidapi"],
     "compositors": ["any"],
     "distro": ["any"],
-    "screenshot": "https://github.com/Crambeary/dms-aerox3-battery-widget/blob/main/screenshot.png"
+    "screenshot": "https://github.com/Crambeary/dms-aerox3-battery-widget/blob/main/screenshots/popout.png"
 }


### PR DESCRIPTION
## Summary
- Adds `aerox3Battery`, a DankBar widget showing the battery level of a SteelSeries Aerox 3 Wireless Gen 2 mouse
- Reads battery via a pinned, patched copy of [rivalcfg](https://github.com/flozz/rivalcfg) vendored directly in the plugin repo (this mouse's USB PIDs, and a core fix the readings need, aren't in any released rivalcfg version yet — see the plugin's `vendor/NOTICE.md`)
- Cascading low-battery notifications at 20/15/10/5%, matching DMS's own first-party `DankBatteryAlerts` style
- Ships `setup.sh`, an idempotent wizard that installs/checks the two things that can't be vendored (the hidapi Python module and a udev rule for hidraw access), skipping anything already done and finishing with a live check against the mouse. The popout also surfaces a "Copy Setup Command" button when the mouse isn't detected, rather than making users hunt for manual steps.
- Plugin repo: https://github.com/Crambeary/dms-aerox3-battery-widget

## Test plan
- [x] `python3 .github/generate.py --validate` passes
- [x] `python3 .github/validate_links.py` passes
- [x] Verified live against the mouse over 2.4GHz wireless (PID 1038:1890) — discharging state
- [x] Verified live against the mouse over wired USB (PID 1038:1892) — charging state
- [x] `setup.sh` verified idempotent (re-run against an already-configured machine correctly skips both steps and passes the live check)
- [ ] Bluetooth: the mouse supports it, but rivalcfg has no device profile for whatever PID it reports over BT, so the widget won't detect it there yet — untested for that reason, and separately untestable on my end since my Bluetooth adapter is currently broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CMbUNaUsxbEqyDmiuSx32