### PR TITLE
[plugin] Add MangoWM Layout Manager

### DIFF
--- a/plugins/omarluq-mangowm-layout-manager.json
+++ b/plugins/omarluq-mangowm-layout-manager.json
@@ -1,0 +1,14 @@
+{
+    "id": "mangoWmLayoutManager",
+    "name": "MangoWM Layout Manager",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/omarluq/DMSMangoWCLayoutManager",
+    "author": "omarluq",
+    "description": "Switch MangoWM layouts from DankBar with visual previews, configurable click shortcuts, and scroll cycling.",
+    "dependencies": ["mmsg"],
+    "compositors": ["mangowc"],
+    "distro": ["any"],
+    "requires_dms": ">=1.2.0",
+    "screenshot": "https://raw.githubusercontent.com/omarluq/DMSMangoWCLayoutManager/main/screenshot.png"
+}


### PR DESCRIPTION
## Plugin
Adds MangoWM Layout Manager, a DankBar widget with visual layout previews, configurable right/middle-click toggles, and scroll cycling.

- Repository: https://github.com/omarluq/DMSMangoWCLayoutManager
- Requires MangoWM and `mmsg`
- Uses the existing registry compositor tag `mangowc`
- Registry ID and name match the published `plugin.json`
- Includes a direct screenshot URL

## Validation
- `python3 .github/generate.py --validate` passed
- `CHANGED_PLUGINS=plugins/omarluq-mangowm-layout-manager.json python3 .github/validate_links.py` passed
- Plugin tested by the author in a running DMS/MangoWM session