### PR TITLE
[plugin] Add Dank News RSS & Ticker and Dank News RSS & Ticker Pill

### DIFF
--- a/plugins/xn4m3d-dank-news-rss-ticker-pill.json
+++ b/plugins/xn4m3d-dank-news-rss-ticker-pill.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankNewsRssTickerPill",
+    "name": "Dank News RSS & Ticker Pill",
+    "capabilities": ["dankbar-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Xn4m3d/dms-rss-widget",
+    "path": "dankNewsRssTickerPill",
+    "author": "Xn4m3d",
+    "description": "Bar companion for Dank News RSS & Ticker: the same scrolling headlines as a compact pill inside the DankBar",
+    "dependencies": [],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Xn4m3d/dms-rss-widget/main/screenshots/pill-plugin.png"
+}

--- a/plugins/xn4m3d-dank-news-rss-ticker.json
+++ b/plugins/xn4m3d-dank-news-rss-ticker.json
@@ -1,0 +1,14 @@
+{
+    "id": "dankNewsRssTicker",
+    "name": "Dank News RSS & Ticker",
+    "capabilities": ["desktop-widget"],
+    "category": "utilities",
+    "repo": "https://github.com/Xn4m3d/dms-rss-widget",
+    "path": "dankNewsRssTicker",
+    "author": "Xn4m3d",
+    "description": "RSS/Atom feeds as a desktop card plus a full-width scrolling news ticker that docks under your bar, follows a bottom bar, or floats",
+    "dependencies": ["curl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Xn4m3d/dms-rss-widget/main/screenshots/screen1.png"
+}


### PR DESCRIPTION
Two entries from the same repository (`Xn4m3d/dms-rss-widget`), submitted as monorepo entries via `path`.

### Dank News RSS & Ticker (`dankNewsRssTicker`, desktop-widget)

RSS/Atom feeds as a desktop card, plus a full-width scrolling news ticker. The ticker magnet-snaps to the top, to just under the main bar, or to the screen bottom — the two docked positions reserve space — and floats behind windows anywhere in between. It follows the DankBar's position, including live changes and vertical bars.

### Dank News RSS & Ticker Pill (`dankNewsRssTickerPill`, dankbar-widget)

The same scrolling headlines as a compact pill inside the DankBar. It fetches nothing of its own: it reads the item cache the desktop widget writes, so both stay in sync with no extra network traffic. The two are mutually exclusive — the headlines scroll in exactly one place, chosen from a single control mirrored in both settings panels.

### Relationship to `dankRssWidget` (BrendonJL)

This is a fork of [BrendonJL/dms-rss-widget](https://github.com/BrendonJL/dms-rss-widget), and full credit for the original desktop RSS widget goes to him. Same MIT license.

The fixes I made along the way were offered back upstream rather than kept here, and four were merged: [#1](https://github.com/BrendonJL/dms-rss-widget/pull/1) (feed-fetching and link hardening), [#2](https://github.com/BrendonJL/dms-rss-widget/pull/2) (blank flash when the widget is recreated on resize), [#3](https://github.com/BrendonJL/dms-rss-widget/pull/3) (stray clicks from the Niri overview), [#5](https://github.com/BrendonJL/dms-rss-widget/pull/5) (duplicate items when a fetch overlaps another).

What is being listed here is the **ticker** — the scrolling bar and its pill companion — which does not exist upstream. The ids and display names are deliberately distinct from `dankRssWidget` / "Dank RSS Widget" so the two entries can coexist in the registry and so an install never resolves to the wrong one.

### Details

- **Dependencies:** `curl` for the desktop widget (feed fetching), none for the pill.
- **Compositors:** `any`. The only compositor-specific code is a guard that ignores clicks delivered while Niri's overview is open; it is inert everywhere else. This matches the upstream entry's `compositors`.
- **Tests:** the feed-parsing logic is mirrored in a standalone JS module so it can run under `node --test` without the QML runtime — 64 tests across 10 suites covering tag extraction, CDATA, entity decoding, RSS/Atom parsing and routing, image extraction, relative timestamps and OPML import.
- Validated locally with `python3 .github/generate.py --validate` and `python3 .github/validate_links.py`.

Tested on Niri with DankMaterialShell 1.6.0, from a clean uninstall/reinstall of both plugins. The `any` above is a deliberate claim rather than an untested guess: the only compositor-specific code reads `NiriService.inOverview`, which ships in the shared DMS bundle and simply stays false elsewhere. I have not run it on Hyprland myself, so if a maintainer would rather see `["hyprland", "niri"]` or `["niri"]` there, say the word and I'll change it.
