### PR TITLE
[plugin] Add Niri Workspace Bar

### DIFF
--- a/plugins/robwilkerson-niri-workspace-bar.json
+++ b/plugins/robwilkerson-niri-workspace-bar.json
@@ -1,0 +1,14 @@
+{
+    "id": "niriWorkspaceBar",
+    "name": "Niri Workspace Bar",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/robwilkerson/dms-niri-workspace-bar",
+    "author": "Rob Wilkerson",
+    "description": "The focused niri workspace as a pill segmented to match its column count, plus a grouped switcher for every named workspace.",
+    "dependencies": [],
+    "compositors": ["niri"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/robwilkerson/dms-niri-workspace-bar/main/docs/screenshot.png",
+    "requires_dms": ">=1.4.0"
+}


### PR DESCRIPTION
A dankbar widget for niri that shows the focused workspace as a pill segmented to match its column count, with the active column drawn at full strength and the rest faded.

Clicking the widget opens a switcher listing every named workspace, organized into groups defined in the plugin's own settings pane. niri has no grouping concept of its own, so the grouping lives entirely in plugin settings, and the workspace pool is read from `config.kdl` and every file it `include`s.

Validated locally with `generate.py --validate` and `validate_links.py`, both passing.