### PR TITLE
[plugin] Update dankRssWidget entry

### DIFF
--- a/plugins/brendonjl-dankrsswidget.json
+++ b/plugins/brendonjl-dankrsswidget.json
@@ -4,9 +4,9 @@
     "capabilities": ["desktop-widget"],
     "category": "utilities",
     "repo": "https://github.com/BrendonJL/dms-rss-widget",
-    "author": "BrendonJL",
-    "description": "Desktop widget that displays RSS/Atom feeds with auto-refresh",
-    "dependencies": [],
+    "author": "BrendonJL, Xn4m3d, Alessandro Ianne",
+    "description": "Desktop widget that displays RSS/Atom feeds with auto-refresh, plus full Miniflux integration with bidirectional read/unread/starred sync",
+    "dependencies": ["curl"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/BrendonJL/dms-rss-widget/main/screenshot.png"


### PR DESCRIPTION
Updates the existing `dankRssWidget` entry to match `plugin.json` on `main`.

- **description** — still described the v1 feature set; the plugin has had full
  Miniflux integration (bidirectional read/unread/starred sync) since 2.3.0
- **author** — now credits @Xn4m3d and Alessandro Ianne (@alexanderi96), whose
  PRs shipped in 2.3.0
- **dependencies** — was `[]`; feed fetching shells out to `curl`

No change to `id`, `name`, `repo` or `screenshot`.

Both validators pass locally:

```
python3 .github/generate.py --validate    → Validation successful!
python3 .github/validate_links.py         → Checking brendonjl-dankrsswidget.json... OK
                                        All plugins validated successfully!
```

Context: discussed on #364, where the unmaintained flag was cleared. The
`version` field is tracking `plugin.json` on its own and needs nothing here.
