### PR TITLE
[plugin] Add AI Usage for Codex and Claude quotas

### DIFF
--- a/plugins/alcxyz-dank-ai-usage.json
+++ b/plugins/alcxyz-dank-ai-usage.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankAIUsage",
+    "name": "AI Usage",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/alcxyz/DankAIUsage",
+    "author": "alcxyz",
+    "description": "Monitor Codex and Claude subscription quotas, extra-usage credits, and local token history with switchable used/remaining views and quick bar controls",
+    "dependencies": ["dankaiusage", "codex", "claude", "sqlite3"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankAIUsage/main/docs/screenshot.png"
+}


### PR DESCRIPTION
Adds AI Usage, a DankBar widget for Codex and Claude subscription quotas, extra-usage credits, and local token history.

The widget offers a Left/Used display toggle and quick controls for the bar's quota selection and icons. The entry points to the released v0.4.0 plugin and a screenshot hosted on the repository's main branch.

The focus is a small dependency footprint for existing Codex and Claude users, without requiring a separate third-party quota application or proxy service. The widget and its Go helper are maintained together in the plugin repository. Codex quotas come from the local Codex app server; Claude quotas use the existing Claude Code sign-in to query the provider's usage endpoint. Unlike the CodexBar integration or CLIProxyAPI Quota, this setup does not require CodexBar or a CLIProxyAPI/pi-bridge server. Other registry plugins also use provider sign-ins directly; this is a focused alternative, not a claim that every other plugin needs additional applications.

The `dankaiusage` helper must be installed separately; the README covers Nix and manual installation. Users need the CLI and sign-in for each provider they enable, plus `sqlite3` for Codex local token history. Claude prime is optional and disabled by default.

Validation: registry schema checks and repository, manifest, and screenshot link checks.
