### PR TITLE
[plugin] Add DankSession

### DIFF
--- a/plugins/alcxyz-dank-session.json
+++ b/plugins/alcxyz-dank-session.json
@@ -1,0 +1,13 @@
+{
+    "id": "dankSession",
+    "name": "DankSession",
+    "capabilities": ["dankbar-widget"],
+    "category": "system",
+    "repo": "https://github.com/alcxyz/DankSession",
+    "author": "alcxyz",
+    "description": "Save and restore Hyprland application sessions, workspaces, and window sizes, with automatic saving, login restoration, and app exclusions",
+    "dependencies": ["danksession", "hyprctl", "systemd-run"],
+    "compositors": ["hyprland"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/alcxyz/DankSession/main/assets/screenshot.png"
+}


### PR DESCRIPTION
Adds DankSession, a DankMaterialShell bar widget backed by a Go session service for Hyprland.

- Automatic session saving and opt-in login restoration.
- Saved-window list showing workspaces, dimensions, and restore eligibility.
- Restore scrolling-column widths, stacked-window heights, and floating geometry, with documented limitations.
- Configurable save frequency and app exclusions. Only explicitly configured applications can be relaunched.

Release: https://github.com/alcxyz/DankSession/releases/tag/v0.3.5
Installation and limitations: https://github.com/alcxyz/DankSession#readme

The widget requires the separately installed danksession backend, hyprctl, and systemd-run. Supports Hyprland only.

Screenshot uses a stable main-branch URL. Registry schema and changed-entry link validation both pass.