### PR TITLE
Add Codex Usage monitoring plugin

### DIFF
--- a/plugins/mir4zul-codex-usage.json
+++ b/plugins/mir4zul-codex-usage.json
@@ -1,0 +1,21 @@
+{
+  "id": "codexUsage",
+  "name": "Codex Usage",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "monitoring",
+  "repo": "https://github.com/mir4zul/dms-codex-usage",
+  "author": "mir4zul",
+  "description": "Two progress rings for locally recorded Codex five-hour and weekly usage, with remaining percentages and reset countdowns.",
+  "dependencies": [
+    "python3"
+  ],
+  "compositors": [
+    "hyprland"
+  ],
+  "distro": [
+    "any"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/mir4zul/dms-codex-usage/main/assets/screenshot.png"
+}

--- a/plugins/mir4zul-codex-usage.json
+++ b/plugins/mir4zul-codex-usage.json
@@ -5,7 +5,7 @@
     "dankbar-widget"
   ],
   "category": "monitoring",
-  "repo": "https://github.com/mir4zul/dms-codex-usage",
+  "repo": "https://github.com/mir4zul/codex-usage",
   "author": "mir4zul",
   "description": "Two progress rings for locally recorded Codex five-hour and weekly usage, with remaining percentages and reset countdowns.",
   "dependencies": [
@@ -17,5 +17,5 @@
   "distro": [
     "any"
   ],
-  "screenshot": "https://raw.githubusercontent.com/mir4zul/dms-codex-usage/main/assets/screenshot.png"
+  "screenshot": "https://raw.githubusercontent.com/mir4zul/codex-usage/main/assets/screenshot.png"
 }

--- a/plugins/mir4zul-codex-usage.json
+++ b/plugins/mir4zul-codex-usage.json
@@ -12,7 +12,7 @@
     "python3"
   ],
   "compositors": [
-    "hyprland"
+    "any"
   ],
   "distro": [
     "any"


### PR DESCRIPTION
Adds Codex Usage, a DankBar widget displaying locally recorded five-hour and weekly Codex quota, reset countdowns, token activity, and model usage. Reads local session logs with Python 3; tested on Hyprland. Repository documentation and a screenshot are included. Validation: registry schema validation and targeted repository, screenshot, ID, and name link checks passed.