### PR TITLE
[plugin] Update DankAIUsage dependencies for v0.7.0

### DIFF
--- a/plugins/alcxyz-dank-ai-usage.json
+++ b/plugins/alcxyz-dank-ai-usage.json
@@ -6,7 +6,7 @@
     "repo": "https://github.com/alcxyz/DankAIUsage",
     "author": "alcxyz",
     "description": "Monitor Codex and Claude subscription quotas, extra-usage credits, and local token history with switchable used/remaining views and quick bar controls",
-    "dependencies": ["dankaiusage", "codex", "claude", "sqlite3"],
+    "dependencies": ["dankaiusage", "codex", "claude"],
     "compositors": ["any"],
     "distro": ["any"],
     "screenshot": "https://raw.githubusercontent.com/alcxyz/DankAIUsage/main/docs/screenshot.png"


### PR DESCRIPTION
## Summary

- remove the obsolete `sqlite3` dependency from the DankAIUsage registry entry
- preserve the existing plugin metadata and stable screenshot URL

## Release

https://github.com/alcxyz/DankAIUsage/releases/tag/v0.7.0