### PR TITLE
[plugin] Add Network Status

### DIFF
--- a/plugins/noahm-05-net-status.json
+++ b/plugins/noahm-05-net-status.json
@@ -1,0 +1,13 @@
+{
+    "id": "netStatus",
+    "name": "Network Status",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/noahm-05/dms-net-status",
+    "author": "Noah",
+    "description": "Shows your local machine IP, active VPN tunnel IP, and optional Tailscale IP in the bar. Right-click to cycle between them.",
+    "dependencies": ["iproute2"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/noahm-05/dms-net-status/main/screenshot.png"
+}


### PR DESCRIPTION
## Summary

Adds **Network Status**, a DankBar widget that shows your local machine IP, active VPN tunnel IP, and (optionally) your Tailscale IP — built for keeping connectivity visible during HTB labs and other pentest lab work.

- Bar pill shows one address at a time; right-click cycles between Local, VPN, and Tailscale
- Turns red and reads "VPN off" the instant the tunnel drops
- Left-click opens a popout with all addresses and copy-to-clipboard buttons
- VPN/local detection reads interfaces directly via `ip -j addr show`, so it works regardless of whether the tunnel came up through `openvpn`, `wg-quick`, or NetworkManager
- Tailscale support reuses DMS's own `TailscaleService`, no extra process

Repo: https://github.com/noahm-05/dms-net-status

## Test plan

- [x] `python3 .github/generate.py --validate` passes
- [x] `id`/`name` in the registry entry match `plugin.json` in the linked repo
- [x] Screenshot and repo URLs return 200
- [x] Verified locally in DMS via `dms ipc call plugins enable/reload/status netStatus`