### PR TITLE
[plugin] Add TS6 Monitor

### DIFF
--- a/plugins/lemon-mon-254-ts6-monitor.json
+++ b/plugins/lemon-mon-254-ts6-monitor.json
@@ -1,0 +1,13 @@
+{
+    "id": "tsMonitor",
+    "name": "TS6 Monitor",
+    "capabilities": ["dankbar-widget"],
+    "category": "monitoring",
+    "repo": "https://github.com/Lemon-mon-254/dms-plugin-TS6Monitor",
+    "author": "Lemon-mon-254",
+    "description": "TeamSpeak 6 voice status monitor for the bar: live mic/mute/away state, channel members with avatars and volume bars, one-click virtual-key controls, and an on-screen volume OSD via TS6 Remote Apps.",
+    "dependencies": ["pactl"],
+    "compositors": ["any"],
+    "distro": ["any"],
+    "screenshot": "https://raw.githubusercontent.com/Lemon-mon-254/dms-plugin-TS6Monitor/main/screenshots/ts.png"
+}


### PR DESCRIPTION
Add a registry entry for **TS6 Monitor**, a TeamSpeak 6 voice status widget for DankMaterialShell.

**Entry file**: `plugins/lemon-mon-254-ts6-monitor.json`

| Field | Value |
|---|---|
| id | `tsMonitor` |
| name | TS6 Monitor |
| repo | https://github.com/Lemon-mon-254/dms-plugin-TS6Monitor |
| capabilities | `["dankbar-widget"]` |
| category | monitoring |
| compositors | any |
| distro | any |
| dependencies | pactl |

**Features**: live mic/mute/away status on the bar pill, channel member avatars with speaking ring, per-member volume bars and on-screen volume OSD via the TS6 Remote Apps API, one-click virtual-key buttons, bilingual 中文/EN UI.

**Validation**: `jq .` syntax OK; `id`/`name` match the repo `plugin.json` exactly; repo is public with README (中文 + English), MIT LICENSE and screenshot included.