### PR TITLE
[plugin] Add Screenshot+

### DIFF
--- a/plugins/pcmid-screenshot-plus.json
+++ b/plugins/pcmid-screenshot-plus.json
@@ -1,0 +1,20 @@
+{
+    "id": "screenshotPlus",
+    "name": "Screenshot+",
+    "capabilities": [
+        "daemon",
+        "ipc"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/pcmid/dms-screenshot-plus",
+    "author": "pcmid",
+    "description": "Region screenshot with live annotation: draw while you select. Rectangle, ellipse, line, arrow, pen, highlighter, text, mosaic and numbered markers. The selection stays movable and resizable with the toolbar following it; the result is copied to the clipboard or saved to a file at native resolution.",
+    "dependencies": [],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/pcmid/dms-screenshot-plus/main/screenshots/screenshot.png"
+}


### PR DESCRIPTION
Adds Screenshot+, a region screenshot tool with live annotation for DankMaterialShell.

- Draw on the screenshot while the selection is still open: rectangle, ellipse, line, arrow, pen, highlighter, text, mosaic and numbered markers
- The selection stays movable and resizable; annotations stay anchored to the picture and the toolbar follows the selection
- Select, move and delete annotations, with snapshot undo/redo
- Copies to the clipboard and/or saves to a file at native resolution, with a notification
- Settings page to choose the tools, the default style, the output and the capture backend
- Ships a zh_CN translation in `translations/`

Repository: https://github.com/pcmid/dms-screenshot-plus (MIT). Requires DMS 1.6.0 or later; developed and tested on niri.

Validated locally with `generate.py --validate` and `validate_links.py`.
