### PR TITLE
[plugin] Add Bitwarden Dankbar

### DIFF
--- a/plugins/coldi1337-bitwarden.json
+++ b/plugins/coldi1337-bitwarden.json
@@ -1,0 +1,25 @@
+{
+    "id": "bitwarden",
+    "name": "Bitwarden",
+    "capabilities": [
+        "dankbar-widget",
+        "ipc"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/coldi1337/dms-bitwarden-cli",
+    "author": "coldi1337",
+    "description": "Search and manage Bitwarden or Vaultwarden using the official Bitwarden CLI, with optional PIN and fingerprint unlock.",
+    "dependencies": [
+        "bitwarden-cli",
+        "jq",
+        "wl-clipboard"
+    ],
+    "compositors": [
+        "hyprland"
+    ],
+    "distro": [
+        "arch"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/coldi1337/dms-bitwarden-cli/main/docs/screenshots/dms-settings.png",
+    "requires_dms": ">=1.6.0"
+}

--- a/plugins/coldi1337-bitwarden.json
+++ b/plugins/coldi1337-bitwarden.json
@@ -15,10 +15,10 @@
         "wl-clipboard"
     ],
     "compositors": [
-        "hyprland"
+        "any"
     ],
     "distro": [
-        "arch"
+        "any"
     ],
     "screenshot": "https://raw.githubusercontent.com/coldi1337/dms-bitwarden-cli/main/docs/screenshots/dms-settings.png",
     "requires_dms": ">=1.6.0"


### PR DESCRIPTION
Adds Bitwarden Dankbar, a DankMaterialShell port of Elevate08/qs-bitwarden-cli using the official `bw` CLI. It supports Bitwarden and Vaultwarden in a DankBar panel, with vault search, item management and optional PIN/fingerprint unlock. This differs from the existing rbw-based launcher plugin.

The registry entry uses `any` for compositor and distribution, as requested in review. Interactive testing was performed on Arch Linux with Hyprland. Optional active-window suggestions currently require Hyprland (`hyprctl`); manual vault search is independent of that integration. Dependency installation is manual on distributions without `pacman`. These limitations are documented in the README. Login, search and fingerprint unlock were confirmed interactively. The port passed 43 Node tests and 45 QtTest checks (including English/German button layouts). Optional fingerprint/PIN storage requires a Secret Service provider; setup and dependencies are documented in the plugin README.

English and German UI translations ship with the plugin and follow the DMS language setting. German is provided locally; central POEditor enrollment is not requested.

The preview renders the actual plugin QML controls in an isolated scene with a fictional demo vault and an inert backend. It includes no real credentials. A reproducible renderer is included in the plugin repository. Original MIT attribution is retained.

Validation: registry schema validation and link/manifest validation.

AI assistance: a substantial part of the DMS adaptation and this registry submission was developed with Codex assistance.
