### PR TITLE
[plugin] Add Clipboard Runner

### DIFF
--- a/plugins/by-architect-clipboard-runner.json
+++ b/plugins/by-architect-clipboard-runner.json
@@ -1,0 +1,26 @@
+{
+    "id": "clipboardRunner",
+    "name": "Clipboard Runner",
+    "capabilities": [
+        "launcher"
+    ],
+    "category": "utilities",
+    "repo": "https://github.com/by-architect/DMS-Plugins",
+    "path": "clipboardRunner",
+    "author": "by-architect",
+    "description": "Run your own commands against whatever you just copied. Each action is filed under a content type -- link, colour, file or text -- and only the ones that fit the clipboard are offered, so typing 'clip' never shows an action that cannot apply.",
+    "dependencies": [
+        "ffmpeg",
+        "imagemagick",
+        "python3",
+        "xdg-utils",
+        "curl"
+    ],
+    "compositors": [
+        "any"
+    ],
+    "distro": [
+        "any"
+    ],
+    "screenshot": "https://raw.githubusercontent.com/by-architect/DMS-Plugins/main/clipboardRunner/docs/screenshot.png"
+}


### PR DESCRIPTION
Adds **Clipboard Runner**, a launcher plugin that runs your own commands against whatever you just copied.

Each action is filed under a content type — link, colour, file or text — and only the actions that fit the current clipboard are offered, so typing `clip ` never shows one that cannot apply.

- Repo: https://github.com/by-architect/DMS-Plugins (monorepo, `path: clipboardRunner`)
- Pure QML; it reads the clipboard through the existing DMS `clipboard.*` API.
- The listed dependencies are what the bundled actions shell out to. They are seeded switched on, so a missing tool is what makes an individual action fail; the plugin itself needs none of them.

`generate.py --validate` passes locally.