### PR TITLE
[plugin] Add DankChat

### DIFF
--- a/plugins/coldi1337-dankchat.json
+++ b/plugins/coldi1337-dankchat.json
@@ -24,5 +24,5 @@
   "distro": [
     "arch"
   ],
-  "screenshot": "https://raw.githubusercontent.com/coldi1337/DankChat/main/docs/preview.png"
+  "screenshot": "https://raw.githubusercontent.com/coldi1337/DankChat/d65e7d00cba55f2c55741b47b40f5b22d8090ba7/docs/preview.png"
 }

--- a/plugins/coldi1337-dankchat.json
+++ b/plugins/coldi1337-dankchat.json
@@ -1,0 +1,28 @@
+{
+  "id": "dankChat",
+  "name": "DankChat",
+  "capabilities": [
+    "dankbar-widget"
+  ],
+  "category": "utilities",
+  "repo": "https://github.com/coldi1337/DankChat",
+  "author": "coldi1337",
+  "description": "Native Telegram and WhatsApp chats with a bar dropdown, tiling window, media previews, emoji search and unread filters.",
+  "dependencies": [
+    "python3",
+    "python-telethon",
+    "python-qrcode",
+    "python-pillow",
+    "wacli 0.17.1",
+    "qt6-multimedia",
+    "qt6-imageformats",
+    "systemd"
+  ],
+  "compositors": [
+    "hyprland"
+  ],
+  "distro": [
+    "arch"
+  ],
+  "screenshot": "https://raw.githubusercontent.com/coldi1337/DankChat/main/docs/preview.png"
+}


### PR DESCRIPTION
DankChat combines Telegram and WhatsApp in one native DMS plugin: a DankBar dropdown and a regular tiling-capable window, with QR linking, unread filters, chat pins, reply navigation, inline media, searchable emoji reactions and explicit read-state actions. It uses Telethon and wacli, with no Electron or embedded browser.

This adds one registry entry. The source is in https://github.com/coldi1337/DankChat. The preview is a real render of the QML interface using only synthetic conversations. The registry entry uses `any` for both compositor and distribution: DankChat uses DMS APIs without direct Hyprland or Arch dependencies. Hands-on validation remains limited to Arch Linux/Hyprland; other environments have not been tested. The documented runtime dependencies still apply. German translations are bundled locally and central POEditor participation is not claimed.

The maintainer has completed broader hands-on testing and reported that the features available at that time worked without issues in their setup. The new clipboard/attachment changes have automated coverage; separate hands-on acceptance is not claimed. This PR is ready for review. Earlier development crashes and fixes remain documented in the validation record; the previous draft hold is lifted based on this acceptance report. No additional compositor/distribution coverage is claimed.

The latest release, [v0.3.0](https://github.com/coldi1337/DankChat/releases/tag/v0.3.0), adds clipboard image/file-list pasting with an attachment preview, up to 10 sequential attachments, and a themed composer reply box. It includes the earlier emoji reactions and MP4-based WhatsApp GIF fix. Clipboard images/file lists require `wl-clipboard`; files are never sent merely by pasting. Sending stops on failure without automatic retries. Native album sending is not implemented.

![DankChat preview — synthetic conversations](https://raw.githubusercontent.com/coldi1337/DankChat/v0.3.0/docs/preview.png)

Registry installation requires the documented Python virtualenv, wacli 0.17.1 and user-unit setup; these are not installed automatically by the registry.

Validation:
- Maintainer-reported broader hands-on acceptance of the current features, confirmed on 2026-09-13.
- Registry schema and link/manifest validation for this entry.
- 45 project Python tests; 152 passing retained WhatsApp tests, one intentional upstream installer skip; both QtTest suites, QML parsing and manifest schema.
- Isolated English/German UI tests with dropdown/window modes, clipboard staging and multi-attachment previews; a 200-step service run includes sequential sending and stopping on a simulated partial failure. All use synthetic data. No agent tests sent real messages, changed real pins/read state or revoked real sessions.
- Installer tests cover a fresh external checkout path and an existing registry plugin path, with DMS/systemd commands isolated.

AI disclosure: a meaningful part of the implementation, tests and documentation was AI-assisted. The agent inspected the submitted registry diff and executed the checks above; this does not claim an independent human audit of every source line. Original upstream licenses and Unicode data licensing are retained.

